### PR TITLE
feat: lista de compras — capa de datos, Firestore y wire-up

### DIFF
--- a/docs/usecases/shopping-list.md
+++ b/docs/usecases/shopping-list.md
@@ -104,7 +104,15 @@ Feature: A dedicated `/shopping` page where users select recipes and receive a c
 
 **GIVEN** a logged user has a list they want to share  
 **WHEN** they tap "Share" and copy the generated link  
-**THEN** a link is generated in the form `https://bastiann-corp.github.io/FoodPlanerReact/shopping?list=<id>&token=<token>` and anyone with that link can open it, see the full ingredient list, and check items off — but cannot add/remove recipes or edit quantities
+**THEN** a link is generated in the form `https://bastiann-corp.github.io/FoodPlanerReact/shopping?token=<shareToken>` and anyone with that link can open it, see the full ingredient list, and check items off — but cannot add/remove recipes or edit quantities
+
+---
+
+## UC-13b — Shared list stays in sync
+
+**GIVEN** a logged user has shared a list and later modifies it (adds/removes recipes, changes portions)  
+**WHEN** they save the list  
+**THEN** the shared view is updated atomically in the same write — any recipient who refreshes their link sees the current state immediately, with no action required from the owner
 
 ---
 
@@ -157,12 +165,54 @@ Tomatoes    300g + 2 units
 
 Production base URL: `https://bastiann-corp.github.io/FoodPlanerReact/`
 
-Share links must be rooted at this URL since the app is hosted on GitHub Pages under a subpath. The share route should follow the pattern:
+Share links must be rooted at this URL since the app is hosted on GitHub Pages under a subpath. The share route follows the pattern:
 
 ```
-https://bastiann-corp.github.io/FoodPlanerReact/shopping?list=<listId>&token=<shareToken>
+https://bastiann-corp.github.io/FoodPlanerReact/shopping?token=<shareToken>
 ```
 
-The `token` serves as an unguessable access key (no authentication required to view). The data layer must validate the token against the list before serving the read-only view.
+The `token` is the only parameter needed — it acts as both the lookup key and the access credential (no authentication required to view). The data layer resolves the list by querying `shared_list_views/{shareToken}` directly.
 
-**Implication for routing**: The Next.js `basePath` is already set to `/FoodPlanerReact` for GitHub Pages deployment. Share links must respect this — never generate bare `/shopping?list=...` URLs for sharing; always use the full production URL or rely on `window.location.origin + basePath`.
+**Implication for routing**: The Next.js `basePath` is already set to `/FoodPlanerReact` for GitHub Pages deployment. Share links must respect this — never generate bare `/shopping?token=...` URLs for sharing; always use the full production URL or rely on `window.location.origin + basePath`.
+
+---
+
+### Shared list — technical considerations
+
+#### Why `shared_list_views/{shareToken}` (token as document ID)?
+
+Firestore security rules cannot inspect query parameters or verify that a client "knows" a value at read time unless that value is part of the document path. Storing the share token as the document ID means a simple `allow read: if true` on the `shared_list_views` collection is safe — only someone who knows the unguessable token can ever retrieve the document. The `shopping_lists` collection remains private (owner-only reads/writes) throughout.
+
+#### Document structure
+
+`shared_list_views/{shareToken}`:
+```
+{
+  listId: string,          // back-reference to the source list
+  ownerName: string,       // display name of the owner
+  listName: string,        // name of the list at time of last save
+  recipes: IShoppingListRecipe[],   // full recipe + ingredient snapshot
+  updatedAt: Timestamp
+}
+```
+
+#### Auto-sync via batch write
+
+When the owner saves their list, a single `writeBatch` atomically updates both:
+- `shopping_lists/{listId}` — the private canonical list
+- `shared_list_views/{shareToken}` — the public snapshot
+
+Any recipient who refreshes the share link immediately sees the current state. No webhook, no polling, no secondary trigger needed.
+
+#### Checked state for recipients
+
+Recipients can check items off while shopping, but that state is held **in-memory only** (React state) on their device — it is never written to Firestore. This keeps security rules simple (no write path for anonymous users on `shared_list_views`) and avoids merge conflicts between multiple recipients checking different items. State is lost on tab close, which is acceptable for a shared grocery session.
+
+#### Edge cases
+
+| Scenario | Behaviour |
+|---|---|
+| Owner deletes a recipe after sharing | Next save overwrites the snapshot; recipients see updated list on refresh |
+| Owner renames the list | Reflected in `shared_list_views.listName` on next save |
+| Owner wants to revoke access | Delete the `shared_list_views/{shareToken}` document; the link 404s immediately |
+| Owner generates a new share link | A new `shareToken` is created; old token document can be deleted or left to expire |

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,13 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "shopping_lists",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ownerUid", "order": "ASCENDING" },
+        { "fieldPath": "updatedAt", "order": "DESCENDING" }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -9,5 +9,21 @@ service cloud.firestore {
     match /ingredients/{ingredients} {
       allow get, read, list: if true;
     }
+
+    match /shopping_lists/{listId} {
+      allow read, write: if request.auth != null
+                         && request.auth.uid == resource.data.ownerUid;
+      allow create:      if request.auth != null
+                         && request.auth.uid == request.resource.data.ownerUid;
+    }
+
+    match /shared_list_views/{shareToken} {
+      // Token-as-ID: public read is safe because the token is a UUID (unguessable).
+      allow get, read: if true;
+      allow write:     if request.auth != null
+                       && request.auth.uid == request.resource.data.ownerUid;
+      allow delete:    if request.auth != null
+                       && request.auth.uid == resource.data.ownerUid;
+    }
   }
 }

--- a/src/app/shopping/page.tsx
+++ b/src/app/shopping/page.tsx
@@ -1,6 +1,8 @@
 "use client"
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Card, Snackbar, useMediaQuery, useTheme } from "@mui/material";
-import { useCallback, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { Timestamp } from "@firebase/firestore";
 import { Base } from "@/components/Base";
 import { AnonBanner } from "@/components/Shopping/molecules/AnonBanner";
 import { ListHeader } from "@/components/Shopping/organisms/ListHeader";
@@ -11,113 +13,365 @@ import { EmptyState } from "@/components/Shopping/organisms/EmptyState";
 import { CelebrationBanner } from "@/components/Shopping/organisms/CelebrationBanner";
 import { ReadonlyHeader } from "@/components/Shopping/organisms/ReadonlyHeader";
 import { ShareDialog } from "@/components/Shopping/dialogs/ShareDialog";
-import { ShoppingAisle, ShoppingRecipe, SortMode } from "@/components/Shopping/types";
-import { makeStubAisles } from "@/components/Shopping/stubs";
+import { PageMode, SavedList, ShoppingRecipe, SortMode } from "@/components/Shopping/types";
+import { useAuth } from "@/hooks/useAuth";
+import { IRecipe } from "@/util/models";
+import { IShoppingList, IShoppingListRecipe } from "@/util/models";
+import { foodFamilies } from "@/util/constants";
+import {
+  buildAisles,
+  buildKeepText,
+  buildListPayload,
+  getRecipeIngredientDetails,
+  hydrateSavedList,
+  recipeToShoppingListRecipe,
+  toSavedLists,
+} from "@/util/shoppingListUtils";
+import {
+  createList,
+  getListById,
+  getMostRecentList,
+  getSharedList,
+  getUserLists,
+  saveList,
+  shareList,
+  updateChecked,
+} from "@/lib/firebase/shoppingLists";
+import { getRecipes } from "@/lib/firebase/recipes";
 
-// TODO: replace hardcoded states with real auth + route params once data layer is ready
-const USER_IS_LOGGED_IN = true;
-const IS_READONLY       = false;
+// ---------------------------------------------------------------------------
+// Main page component (wrapped in Suspense below for useSearchParams)
+// ---------------------------------------------------------------------------
 
-export default function ShoppingPage() {
+function ShoppingPageContent() {
   const theme     = useTheme();
-  const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
+  const isDesktop = useMediaQuery(theme.breakpoints.up("md"));
 
-  const [bannerOn, setBannerOn]     = useState(!USER_IS_LOGGED_IN && !IS_READONLY);
-  const [listName, setListName]     = useState('Mi Lista de Compras');
-  const [sortMode, setSortMode]     = useState<SortMode>('aisle');
+  // ── Auth & route mode ──────────────────────────────────────────
+  const { user, loading: authLoading } = useAuth();
+  const searchParams = useSearchParams();
+  const shareToken   = searchParams?.get("token") ?? null;
+
+  const pageMode: PageMode =
+    shareToken ? "readonly" : user ? "owner" : "anonymous";
+
+  // ── Recipe catalog (for autocomplete) ─────────────────────────
+  const [recipeCache, setRecipeCache] = useState<IRecipe[]>([]);
+
+  // ── List identity ──────────────────────────────────────────────
+  const [listId, setListId]               = useState<string | undefined>(undefined);
+  const [listCreatedAt, setListCreatedAt] = useState<Timestamp | undefined>(undefined);
+  const [allLists, setAllLists]           = useState<SavedList[]>([]);
+  const [currentShareToken, setCurrentShareToken] = useState<string | undefined>(undefined);
+  const [shareUrl, setShareUrl]           = useState<string | undefined>(undefined);
+
+  // ── Shared-view metadata (readonly mode only) ──────────────────
+  const [sharedMeta, setSharedMeta] = useState<{ ownerName: string; ownerInitials: string } | null>(null);
+
+  // ── Shopping state ─────────────────────────────────────────────
+  const [listRecipes, setListRecipes] = useState<IShoppingListRecipe[]>([]);
+  const [checkedIds, setCheckedIds]   = useState<Set<string>>(new Set());
+  const [listName, setListName]       = useState("Mi lista de compras");
+
+  // ── UI state ───────────────────────────────────────────────────
+  const [isDirty, setIsDirty]       = useState(false);
+  const [bannerOn, setBannerOn]     = useState(true);
+  const [sortMode, setSortMode]     = useState<SortMode>("aisle");
   const [shareOpen, setShareOpen]   = useState(false);
-  const [snackMsg, setSnackMsg]     = useState('');
+  const [snackMsg, setSnackMsg]     = useState("");
   const snackTimer                  = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const [selRecipes, setSelRecipes] = useState<ShoppingRecipe[]>([]);
-  const [aisles, setAisles]         = useState<ShoppingAisle[]>([]);
+  // ── Derived state ──────────────────────────────────────────────
+
+  /** ShoppingRecipe[] for the RecipeSelector chip row (UI shape). */
+  const selRecipes: ShoppingRecipe[] = useMemo(
+    () =>
+      listRecipes.map(r => ({
+        id: r.recipeId,
+        name: r.name,
+        emoji: foodFamilies.find(f => f.id === r.family)?.icon ?? "🍽️",
+        portions: r.portions,
+        basePortions: r.basePortions,
+      })),
+    [listRecipes]
+  );
+
+  /** ShoppingRecipe[] for the Autocomplete options. */
+  const availableRecipes: ShoppingRecipe[] = useMemo(
+    () =>
+      recipeCache.map(r => ({
+        id: r.id!,
+        name: r.name,
+        emoji: foodFamilies.find(f => f.id === r.family)?.icon ?? "🍽️",
+        portions: r.portions,
+        basePortions: r.portions,
+      })),
+    [recipeCache]
+  );
+
+  /** Consolidated aisle grouping — replaces makeStubAisles(). */
+  const aisles = useMemo(
+    () => buildAisles(listRecipes, checkedIds, sortMode),
+    [listRecipes, checkedIds, sortMode]
+  );
+
+  // ── Data loading effects ───────────────────────────────────────
+
+  // Load recipe catalog once on mount (needed for autocomplete)
+  useEffect(() => {
+    getRecipes({}).then(recipes => setRecipeCache(recipes ?? []));
+  }, []);
+
+  // Load list state after auth resolves
+  useEffect(() => {
+    if (authLoading) return;
+
+    if (pageMode === "readonly" && shareToken) {
+      getSharedList(shareToken).then(view => {
+        if (!view) return; // TODO: show "link expired" state
+        const displayName = view.ownerDisplayName ?? "Usuario";
+        const initials = displayName
+          .split(" ")
+          .map((w: string) => w[0])
+          .join("")
+          .slice(0, 2)
+          .toUpperCase();
+        setSharedMeta({ ownerName: displayName, ownerInitials: initials });
+        setListName(view.name);
+        const { listRecipes: lr } = hydrateSavedList(view);
+        setListRecipes(lr);
+        setCheckedIds(new Set()); // shared viewers always start unchecked
+      });
+      return;
+    }
+
+    if (pageMode === "owner" && user) {
+      Promise.all([
+        getMostRecentList(user.uid),
+        getUserLists(user.uid),
+      ]).then(([recent, lists]) => {
+        setAllLists(toSavedLists(lists));
+        if (!recent) return;
+        setListId(recent.id);
+        setListCreatedAt(recent.createdAt);
+        setListName(recent.name);
+        if (recent.shareToken) {
+          setCurrentShareToken(recent.shareToken);
+          setShareUrl(
+            `https://bastiann-corp.github.io/FoodPlanerReact/shopping?token=${recent.shareToken}`
+          );
+        }
+        const { listRecipes: lr, checkedIngredientIds } = hydrateSavedList(recent);
+        setListRecipes(lr);
+        setCheckedIds(checkedIngredientIds);
+      });
+    }
+    // pageMode === 'anonymous': stays empty, no-op
+  }, [authLoading, user, pageMode, shareToken]);
+
+  // ── Helpers ────────────────────────────────────────────────────
 
   const showSnack = useCallback((msg: string) => {
     if (snackTimer.current) clearTimeout(snackTimer.current);
     setSnackMsg(msg);
-    snackTimer.current = setTimeout(() => setSnackMsg(''), 2200);
+    snackTimer.current = setTimeout(() => setSnackMsg(""), 2200);
   }, []);
 
-  const addRecipe = (recipe: ShoppingRecipe) => {
-    setSelRecipes(prev => {
-      const next = [...prev, recipe];
-      if (!prev.length) setAisles(makeStubAisles());
-      return next;
-    });
+  // ── Recipe manipulation ────────────────────────────────────────
+
+  const addRecipe = (shoppingRecipe: ShoppingRecipe) => {
+    const fullRecipe = recipeCache.find(r => r.id === shoppingRecipe.id);
+    if (!fullRecipe) return;
+    const snapshot = recipeToShoppingListRecipe(fullRecipe, fullRecipe.portions);
+    setListRecipes(prev => [...prev, snapshot]);
+    setIsDirty(true);
   };
 
   const removeRecipe = (id: string) => {
-    setSelRecipes(prev => {
-      const next = prev.filter(r => r.id !== id);
-      if (!next.length) setAisles([]);
+    setListRecipes(prev => prev.filter(r => r.recipeId !== id));
+    setIsDirty(true);
+  };
+
+  const changePortions = (id: string, delta: number) => {
+    setListRecipes(prev =>
+      prev.map(r =>
+        r.recipeId === id ? { ...r, portions: Math.max(1, r.portions + delta) } : r
+      )
+    );
+    setIsDirty(true);
+  };
+
+  const getIngredientDetails = useCallback(
+    (recipeId: string) => {
+      const recipe = listRecipes.find(r => r.recipeId === recipeId);
+      if (!recipe) return [];
+      return getRecipeIngredientDetails(recipe);
+    },
+    [listRecipes]
+  );
+
+  // ── Check-off ──────────────────────────────────────────────────
+
+  const toggleIngredient = (ingredientId: string) => {
+    setCheckedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(ingredientId)) next.delete(ingredientId);
+      else next.add(ingredientId);
+      // Persist immediately (no debounce — check/uncheck should feel instant)
+      if (pageMode === "owner" && listId) {
+        updateChecked(listId, [...next]).catch(() => {});
+      }
+      // Readonly / anonymous: in-memory only (never written to Firestore)
       return next;
     });
   };
 
-  const changePortions = (id: string, delta: number) => {
-    setSelRecipes(prev =>
-      prev.map(r => r.id === id ? { ...r, portions: Math.max(1, r.portions + delta) } : r)
-    );
+  // ── Save ───────────────────────────────────────────────────────
+
+  const handleSave = async () => {
+    if (pageMode !== "owner" || !user) return;
+    const payload = buildListPayload(listName, user.uid, listRecipes, checkedIds, currentShareToken);
+    const id = await saveList(payload, listId, listCreatedAt);
+    if (!listId) {
+      setListId(id);
+      const lists = await getUserLists(user.uid);
+      setAllLists(toSavedLists(lists));
+    }
+    setIsDirty(false);
+    showSnack("Lista guardada");
   };
 
-  const toggleIngredient = (ingredientId: string) => {
-    setAisles(prev =>
-      prev.map(a => ({
-        ...a,
-        items: a.items.map(i => i.id === ingredientId ? { ...i, checked: !i.checked } : i),
-      }))
-    );
+  // ── Clear list ─────────────────────────────────────────────────
+
+  const handleClear = async () => {
+    setListRecipes([]);
+    setCheckedIds(new Set());
+    if (pageMode === "owner" && listId && user) {
+      const payload = buildListPayload(listName, user.uid, [], new Set(), currentShareToken);
+      await saveList(payload, listId, listCreatedAt);
+    }
+    setIsDirty(false);
   };
+
+  // ── Share ──────────────────────────────────────────────────────
+
+  const handleShare = async () => {
+    if (pageMode !== "owner" || !user || !listId) return;
+    // Flush unsaved changes before generating the share link
+    if (isDirty) await handleSave();
+    const token = await shareList(
+      {
+        ownerUid: user.uid,
+        name: listName,
+        recipes: listRecipes,
+        checkedIngredientIds: [...checkedIds],
+        id: listId,
+        shareToken: currentShareToken,
+      } as IShoppingList,
+      user.displayName ?? "Usuario"
+    );
+    setCurrentShareToken(token);
+    const url = `https://bastiann-corp.github.io/FoodPlanerReact/shopping?token=${token}`;
+    setShareUrl(url);
+    setShareOpen(true);
+  };
+
+  // ── New list ───────────────────────────────────────────────────
+
+  const handleNewList = async () => {
+    if (!user) return;
+    const newId = await createList(user.uid, "Mi nueva lista");
+    setListId(newId);
+    setListCreatedAt(undefined);
+    setListName("Mi nueva lista");
+    setListRecipes([]);
+    setCheckedIds(new Set());
+    setCurrentShareToken(undefined);
+    setShareUrl(undefined);
+    setIsDirty(false);
+    const lists = await getUserLists(user.uid);
+    setAllLists(toSavedLists(lists));
+  };
+
+  // ── Select list from switcher ──────────────────────────────────
+
+  const handleSelectList = async (savedList: SavedList) => {
+    const full = await getListById(savedList.id);
+    if (!full) return;
+    setListId(full.id);
+    setListCreatedAt(full.createdAt);
+    setListName(full.name);
+    if (full.shareToken) {
+      setCurrentShareToken(full.shareToken);
+      setShareUrl(
+        `https://bastiann-corp.github.io/FoodPlanerReact/shopping?token=${full.shareToken}`
+      );
+    } else {
+      setCurrentShareToken(undefined);
+      setShareUrl(undefined);
+    }
+    const { listRecipes: lr, checkedIngredientIds } = hydrateSavedList(full);
+    setListRecipes(lr);
+    setCheckedIds(checkedIngredientIds);
+    setIsDirty(false);
+  };
+
+  // ── Copy for Google Keep ───────────────────────────────────────
 
   const handleCopy = () => {
-    const lines = aisles
-      .flatMap(a => a.items)
-      .map(i => `[ ] ${i.qty} ${i.name}`)
-      .join('\n');
-    navigator.clipboard.writeText(lines).catch(() => {});
-    showSnack('Lista copiada al portapapeles');
+    navigator.clipboard.writeText(buildKeepText(aisles)).catch(() => {});
+    showSnack("Lista copiada al portapapeles");
   };
 
-  const allDone    = aisles.length > 0 && aisles.every(a => a.items.every(i => i.checked));
-  const hasContent = selRecipes.length > 0;
+  // ── Computed flags ─────────────────────────────────────────────
 
-  const displayAisles: ShoppingAisle[] = sortMode === 'alpha'
-    ? [{
-        id: 'alpha',
-        icon: '🔤',
-        name: 'Todos los ingredientes',
-        items: [...aisles.flatMap(a => a.items)].sort((x, y) =>
-          x.name.localeCompare(y.name, 'es')
-        ),
-      }]
-    : aisles;
+  const allDone    = aisles.length > 0 && aisles.every(a => a.items.every(i => i.checked));
+  const hasContent = listRecipes.length > 0;
 
   // ── Shared panels ──────────────────────────────────────────────
-  const leftPanel = IS_READONLY
-    ? <ReadonlyHeader ownerName="Andrea B." ownerInitials="AB" listName="Semana del 20 de mayo" />
-    : (
-        <>
-          <ListHeader isLoggedIn={USER_IS_LOGGED_IN} listName={listName} setListName={setListName} />
-          <RecipeSelector
-            selectedRecipes={selRecipes}
-            onAdd={addRecipe}
-            onRemove={removeRecipe}
-            onPortionChange={changePortions}
-          />
-        </>
-      );
+
+  const leftPanel =
+    pageMode === "readonly" ? (
+      <ReadonlyHeader
+        ownerName={sharedMeta?.ownerName ?? ""}
+        ownerInitials={sharedMeta?.ownerInitials ?? ""}
+        listName={listName}
+      />
+    ) : (
+      <>
+        <ListHeader
+          isLoggedIn={pageMode === "owner"}
+          listName={listName}
+          setListName={name => { setListName(name); setIsDirty(true); }}
+          lists={allLists}
+          currentListId={listId ?? ""}
+          onSelectList={handleSelectList}
+          onNewList={handleNewList}
+        />
+        <RecipeSelector
+          availableRecipes={availableRecipes}
+          selectedRecipes={selRecipes}
+          onAdd={addRecipe}
+          onRemove={removeRecipe}
+          onPortionChange={changePortions}
+          getIngredientDetails={getIngredientDetails}
+        />
+      </>
+    );
 
   const actionBarProps = {
     sortMode,
     onSortChange: setSortMode,
-    canShare: USER_IS_LOGGED_IN && !IS_READONLY,
-    onShare: () => setShareOpen(true),
+    canShare: pageMode === "owner" && !!listId,
+    onShare: handleShare,
     onCopy: handleCopy,
+    canSave: isDirty && pageMode === "owner",
+    onSave: handleSave,
   };
 
   const aisleList = (
     <Box pb={1}>
-      {displayAisles.map(a => (
+      {aisles.map(a => (
         <AisleGroup key={a.id} aisle={a} onToggle={toggleIngredient} />
       ))}
     </Box>
@@ -125,50 +379,56 @@ export default function ShoppingPage() {
 
   const dialogs = (
     <>
-      {shareOpen && <ShareDialog onClose={() => setShareOpen(false)} />}
+      {shareOpen && (
+        <ShareDialog
+          onClose={() => setShareOpen(false)}
+          shareUrl={shareUrl}
+        />
+      )}
       <Snackbar
         open={!!snackMsg}
         message={snackMsg}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
       />
     </>
   );
 
-  // ── Desktop layout ──────────────────────────────────────────────
+  // ── Desktop layout ─────────────────────────────────────────────
   if (isDesktop) {
     return (
       <Base>
-        {!USER_IS_LOGGED_IN && !IS_READONLY && bannerOn && (
+        {pageMode === "anonymous" && bannerOn && (
           <AnonBanner onDismiss={() => setBannerOn(false)} />
         )}
 
         <Box
           sx={{
-            display: 'grid',
-            gridTemplateColumns: 'clamp(280px, 28%, 360px) minmax(320px, 1fr)',
+            display: "grid",
+            gridTemplateColumns: "clamp(280px, 28%, 360px) minmax(320px, 1fr)",
             gap: 3,
-            alignItems: 'start',
+            alignItems: "start",
             pt: 3,
             pb: 8,
           }}
         >
           {/* Left: sticky selector card */}
-          <Box sx={{ position: 'sticky', top: '80px', alignSelf: 'start' }}>
-            <Card variant="outlined" sx={{ borderRadius: 2, overflow: 'clip' }}>
+          <Box sx={{ position: "sticky", top: "80px", alignSelf: "start" }}>
+            <Card variant="outlined" sx={{ borderRadius: 2, overflow: "clip" }}>
               {leftPanel}
             </Card>
           </Box>
 
-          {/* Right: ingredient list — ActionBar is static inside the card (not sticky) */}
-          <Card variant="outlined" sx={{ borderRadius: 2, overflow: 'clip', minWidth: 320 }}>
-            {!hasContent
-              ? <EmptyState />
-              : <>
-                  <ActionBar {...actionBarProps} sticky={false} />
-                  {allDone && <CelebrationBanner />}
-                  {aisleList}
-                </>
-            }
+          {/* Right: ingredient list */}
+          <Card variant="outlined" sx={{ borderRadius: 2, overflow: "clip", minWidth: 320 }}>
+            {!hasContent ? (
+              <EmptyState />
+            ) : (
+              <>
+                <ActionBar {...actionBarProps} sticky={false} />
+                {allDone && <CelebrationBanner />}
+                {aisleList}
+              </>
+            )}
           </Card>
         </Box>
 
@@ -177,22 +437,35 @@ export default function ShoppingPage() {
     );
   }
 
-  // ── Mobile layout ───────────────────────────────────────────────
+  // ── Mobile layout ──────────────────────────────────────────────
   return (
     <Base>
-      {!USER_IS_LOGGED_IN && !IS_READONLY && bannerOn && (
+      {pageMode === "anonymous" && bannerOn && (
         <AnonBanner onDismiss={() => setBannerOn(false)} />
       )}
       {leftPanel}
-      {!hasContent
-        ? <EmptyState />
-        : <>
-            <ActionBar {...actionBarProps} sticky />
-            {allDone && <CelebrationBanner />}
-            {aisleList}
-          </>
-      }
+      {!hasContent ? (
+        <EmptyState />
+      ) : (
+        <>
+          <ActionBar {...actionBarProps} sticky />
+          {allDone && <CelebrationBanner />}
+          {aisleList}
+        </>
+      )}
       {dialogs}
     </Base>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Export — Suspense wrapper required for useSearchParams in Next.js 15
+// ---------------------------------------------------------------------------
+
+export default function ShoppingPage() {
+  return (
+    <Suspense>
+      <ShoppingPageContent />
+    </Suspense>
   );
 }

--- a/src/components/Base.tsx
+++ b/src/components/Base.tsx
@@ -46,8 +46,8 @@ const pages = [
     name: "Mi lista",
     route: "/shopping",
     icon: <ShoppingCartRounded/>,
-    enabled: false,
-    inBottomBar: false,
+    enabled: true,
+    inBottomBar: true,
   },
   {
     name: "Sobre la app",

--- a/src/components/Shopping/dialogs/ListSwitcherModal.tsx
+++ b/src/components/Shopping/dialogs/ListSwitcherModal.tsx
@@ -2,15 +2,16 @@
 import { Box, Button, Dialog, DialogContent, DialogTitle, Divider, IconButton, Typography } from "@mui/material";
 import { AddRounded, AssignmentRounded, CheckRounded, CloseRounded } from "@mui/icons-material";
 import { SavedList } from "@/components/Shopping/types";
-import { STUB_SAVED_LISTS } from "@/components/Shopping/stubs";
 
 interface ListSwitcherModalProps {
+  lists: SavedList[];
   currentId: string;
   onSelect: (list: SavedList) => void;
+  onNewList?: () => void;
   onClose: () => void;
 }
 
-export function ListSwitcherModal({ currentId, onSelect, onClose }: ListSwitcherModalProps) {
+export function ListSwitcherModal({ lists, currentId, onSelect, onNewList, onClose }: ListSwitcherModalProps) {
   return (
     <Dialog
       open
@@ -37,7 +38,7 @@ export function ListSwitcherModal({ currentId, onSelect, onClose }: ListSwitcher
       </DialogTitle>
 
       <DialogContent sx={{ pt: 0 }}>
-        {STUB_SAVED_LISTS.map((list, i) => (
+        {lists.map((list, i) => (
           <Box key={list.id}>
             <Box
               onClick={() => { onSelect(list); onClose(); }}
@@ -57,11 +58,11 @@ export function ListSwitcherModal({ currentId, onSelect, onClose }: ListSwitcher
               <AssignmentRounded sx={{ color: 'primary.main', fontSize: 22, flexShrink: 0 }} />
               <Box sx={{ flex: 1 }}>
                 <Typography variant="body2" fontWeight={500}>{list.name}</Typography>
-                <Typography variant="caption" color="text.secondary">{list.itemCount} ingredientes</Typography>
+                <Typography variant="caption" color="text.secondary">{list.itemCount} recetas</Typography>
               </Box>
               {list.id === currentId && <CheckRounded sx={{ color: 'primary.main' }} />}
             </Box>
-            {i < STUB_SAVED_LISTS.length - 1 && <Divider />}
+            {i < lists.length - 1 && <Divider />}
           </Box>
         ))}
 
@@ -69,6 +70,7 @@ export function ListSwitcherModal({ currentId, onSelect, onClose }: ListSwitcher
           fullWidth
           variant="outlined"
           startIcon={<AddRounded />}
+          onClick={() => { onNewList?.(); onClose(); }}
           sx={{
             mt: 1.75,
             borderStyle: 'dashed',

--- a/src/components/Shopping/dialogs/RecipeIngModal.tsx
+++ b/src/components/Shopping/dialogs/RecipeIngModal.tsx
@@ -1,16 +1,16 @@
 "use client"
 import { Box, Divider, Dialog, DialogTitle, DialogContent, IconButton, Typography } from "@mui/material";
 import { CloseRounded } from "@mui/icons-material";
-import { ShoppingRecipe } from "@/components/Shopping/types";
-import { STUB_RECIPE_DETAILS } from "@/components/Shopping/stubs";
+import { RecipeIngredientDetail, ShoppingRecipe } from "@/components/Shopping/types";
 
 interface RecipeIngModalProps {
   recipe: ShoppingRecipe;
+  ingredientDetails: RecipeIngredientDetail[];
   onClose: () => void;
 }
 
-export function RecipeIngModal({ recipe, onClose }: RecipeIngModalProps) {
-  const ingredients = STUB_RECIPE_DETAILS[recipe.id] ?? [];
+export function RecipeIngModal({ recipe, ingredientDetails, onClose }: RecipeIngModalProps) {
+  const ingredients = ingredientDetails;
 
   return (
     <Dialog

--- a/src/components/Shopping/molecules/RecipeChip.tsx
+++ b/src/components/Shopping/molecules/RecipeChip.tsx
@@ -2,16 +2,17 @@
 import { Box, IconButton, Typography } from "@mui/material";
 import { CloseRounded } from "@mui/icons-material";
 import { useState } from "react";
-import { ShoppingRecipe } from "@/components/Shopping/types";
+import { RecipeIngredientDetail, ShoppingRecipe } from "@/components/Shopping/types";
 import { RecipeIngModal } from "@/components/Shopping/dialogs/RecipeIngModal";
 
 interface RecipeChipProps {
   recipe: ShoppingRecipe;
+  ingredientDetails?: RecipeIngredientDetail[];
   onRemove: (id: string) => void;
   onPortionChange: (id: string, delta: number) => void;
 }
 
-export function RecipeChip({ recipe, onRemove, onPortionChange }: RecipeChipProps) {
+export function RecipeChip({ recipe, ingredientDetails = [], onRemove, onPortionChange }: RecipeChipProps) {
   const [modalOpen, setModalOpen] = useState(false);
 
   return (
@@ -138,7 +139,7 @@ export function RecipeChip({ recipe, onRemove, onPortionChange }: RecipeChipProp
       </Box>
 
       {modalOpen && (
-        <RecipeIngModal recipe={recipe} onClose={() => setModalOpen(false)} />
+        <RecipeIngModal recipe={recipe} ingredientDetails={ingredientDetails} onClose={() => setModalOpen(false)} />
       )}
     </>
   );

--- a/src/components/Shopping/molecules/RecipeChip.tsx
+++ b/src/components/Shopping/molecules/RecipeChip.tsx
@@ -49,6 +49,10 @@ export function RecipeChip({ recipe, ingredientDetails = [], onRemove, onPortion
             p: 0,
             fontFamily: 'inherit',
             borderRadius: '3px',
+            maxWidth: '120px',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
             '&:hover': { textDecoration: 'underline', textUnderlineOffset: '2px' },
           }}
         >

--- a/src/components/Shopping/organisms/ActionBar.tsx
+++ b/src/components/Shopping/organisms/ActionBar.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { Box, Button, Tooltip } from "@mui/material";
-import { ContentCopyRounded, IosShareRounded, SortRounded } from "@mui/icons-material";
+import { ContentCopyRounded, IosShareRounded, SaveRounded, SortRounded } from "@mui/icons-material";
 import { SortMode } from "@/components/Shopping/types";
 
 interface ActionBarProps {
@@ -9,10 +9,12 @@ interface ActionBarProps {
   canShare: boolean;
   onShare: () => void;
   onCopy: () => void;
+  canSave?: boolean;
+  onSave?: () => void;
   sticky?: boolean;
 }
 
-export function ActionBar({ sortMode, onSortChange, canShare, onShare, onCopy, sticky = true }: ActionBarProps) {
+export function ActionBar({ sortMode, onSortChange, canShare, onShare, onCopy, canSave, onSave, sticky = true }: ActionBarProps) {
   return (
     <Box
       sx={{
@@ -46,7 +48,18 @@ export function ActionBar({ sortMode, onSortChange, canShare, onShare, onCopy, s
         {sortMode === 'aisle' ? 'Por pasillo' : 'Alfabético'}
       </Button>
 
-      <Box sx={{ ml: 'auto', display: 'flex', gap: 0.25 }}>
+      <Box sx={{ ml: 'auto', display: 'flex', gap: 0.25, alignItems: 'center' }}>
+        {canSave && (
+          <Button
+            size="small"
+            variant="contained"
+            startIcon={<SaveRounded sx={{ fontSize: 16 }} />}
+            onClick={onSave}
+            sx={{ textTransform: 'none', fontSize: '0.75rem', fontWeight: 600 }}
+          >
+            Guardar
+          </Button>
+        )}
         <Button
           size="small"
           startIcon={<ContentCopyRounded sx={{ fontSize: 16 }} />}
@@ -73,6 +86,7 @@ export function ActionBar({ sortMode, onSortChange, canShare, onShare, onCopy, s
           </span>
         </Tooltip>
       </Box>
+
     </Box>
   );
 }

--- a/src/components/Shopping/organisms/ListHeader.tsx
+++ b/src/components/Shopping/organisms/ListHeader.tsx
@@ -5,31 +5,28 @@ import { useRef, useState } from "react";
 import { PillButton } from "@/components/Shopping/atoms/PillButton";
 import { ListSwitcherModal } from "@/components/Shopping/dialogs/ListSwitcherModal";
 import { SavedList } from "@/components/Shopping/types";
-import { STUB_SAVED_LISTS } from "@/components/Shopping/stubs";
 
 interface ListHeaderProps {
   isLoggedIn: boolean;
   listName: string;
   setListName: (name: string) => void;
+  lists?: SavedList[];
+  currentListId?: string;
+  onSelectList?: (list: SavedList) => void;
+  onNewList?: () => void;
 }
 
-export function ListHeader({ isLoggedIn, listName, setListName }: ListHeaderProps) {
+export function ListHeader({ isLoggedIn, listName, setListName, lists = [], currentListId = '', onSelectList, onNewList }: ListHeaderProps) {
   const [editing, setEditing]       = useState(false);
   const [switcherOpen, setSwitcher] = useState(false);
-  const [currentListId, setListId]  = useState('l1');
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const currentList = STUB_SAVED_LISTS.find(l => l.id === currentListId) ?? STUB_SAVED_LISTS[0];
+  const currentList = lists.find(l => l.id === currentListId) ?? lists[0];
 
   const startEdit = () => {
     if (!isLoggedIn) return;
     setEditing(true);
     setTimeout(() => inputRef.current?.focus(), 20);
-  };
-
-  const handleSelect = (list: SavedList) => {
-    setListId(list.id);
-    setListName(list.name);
   };
 
   return (
@@ -93,7 +90,7 @@ export function ListHeader({ isLoggedIn, listName, setListName }: ListHeaderProp
           {isLoggedIn && (
             <Box
               component="button"
-              onClick={() => setSwitcher(true)}
+              onClick={() => { onNewList?.(); }}
               sx={{
                 ml: 'auto',
                 color: 'primary.main',
@@ -122,8 +119,10 @@ export function ListHeader({ isLoggedIn, listName, setListName }: ListHeaderProp
 
       {switcherOpen && (
         <ListSwitcherModal
+          lists={lists}
           currentId={currentListId}
-          onSelect={handleSelect}
+          onSelect={(list) => { onSelectList?.(list); setListName(list.name); }}
+          onNewList={onNewList}
           onClose={() => setSwitcher(false)}
         />
       )}

--- a/src/components/Shopping/organisms/ListHeader.tsx
+++ b/src/components/Shopping/organisms/ListHeader.tsx
@@ -21,7 +21,7 @@ export function ListHeader({ isLoggedIn, listName, setListName, lists = [], curr
   const [switcherOpen, setSwitcher] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const currentList = lists.find(l => l.id === currentListId) ?? lists[0];
+  const currentList = lists.find(l => l.id === currentListId) ?? lists[0] ?? null;
 
   const startEdit = () => {
     if (!isLoggedIn) return;
@@ -84,7 +84,7 @@ export function ListHeader({ isLoggedIn, listName, setListName, lists = [], curr
             endIcon={<ExpandMoreRounded sx={{ fontSize: 15, color: 'text.secondary' }} />}
             disabled={!isLoggedIn}
           >
-            {currentList.shortName}
+            {currentList?.shortName ?? 'Mi lista'}
           </PillButton>
 
           {isLoggedIn && (

--- a/src/components/Shopping/organisms/RecipeSelector.tsx
+++ b/src/components/Shopping/organisms/RecipeSelector.tsx
@@ -1,19 +1,20 @@
 "use client"
 import { Autocomplete, Box, TextField, Typography } from "@mui/material";
 import { AddCircleOutlineRounded } from "@mui/icons-material";
-import { ShoppingRecipe } from "@/components/Shopping/types";
-import { STUB_RECIPES } from "@/components/Shopping/stubs";
+import { RecipeIngredientDetail, ShoppingRecipe } from "@/components/Shopping/types";
 import { RecipeChip } from "@/components/Shopping/molecules/RecipeChip";
 
 interface RecipeSelectorProps {
+  availableRecipes: ShoppingRecipe[];
   selectedRecipes: ShoppingRecipe[];
   onAdd: (recipe: ShoppingRecipe) => void;
   onRemove: (id: string) => void;
   onPortionChange: (id: string, delta: number) => void;
+  getIngredientDetails?: (recipeId: string) => RecipeIngredientDetail[];
 }
 
-export function RecipeSelector({ selectedRecipes, onAdd, onRemove, onPortionChange }: RecipeSelectorProps) {
-  const available = STUB_RECIPES.filter(r => !selectedRecipes.find(s => s.id === r.id));
+export function RecipeSelector({ availableRecipes, selectedRecipes, onAdd, onRemove, onPortionChange, getIngredientDetails }: RecipeSelectorProps) {
+  const available = availableRecipes.filter(r => !selectedRecipes.find(s => s.id === r.id));
 
   return (
     <Box sx={{ px: 2, pt: 1.5, pb: 0.25, borderBottom: '1px solid', borderColor: 'divider' }}>
@@ -75,6 +76,7 @@ export function RecipeSelector({ selectedRecipes, onAdd, onRemove, onPortionChan
             <RecipeChip
               key={r.id}
               recipe={r}
+              ingredientDetails={getIngredientDetails?.(r.id) ?? []}
               onRemove={onRemove}
               onPortionChange={onPortionChange}
             />

--- a/src/components/Shopping/organisms/RecipeSelector.tsx
+++ b/src/components/Shopping/organisms/RecipeSelector.tsx
@@ -48,8 +48,8 @@ export function RecipeSelector({ availableRecipes, selectedRecipes, onAdd, onRem
             }}
           />
         )}
-        renderOption={(props, recipe) => (
-          <Box component="li" {...props} sx={{ gap: 1.25, py: 1.25, px: 1.75 }}>
+        renderOption={({ key, ...props }, recipe) => (
+          <Box key={key} component="li" {...props} sx={{ gap: 1.25, py: 1.25, px: 1.75 }}>
             <Typography component="span" sx={{ fontSize: '1.375rem' }}>{recipe.emoji}</Typography>
             <Box sx={{ flex: 1 }}>
               <Typography variant="body2" fontWeight={500}>{recipe.name}</Typography>

--- a/src/components/Shopping/types.ts
+++ b/src/components/Shopping/types.ts
@@ -34,3 +34,6 @@ export interface SavedList {
 }
 
 export type SortMode = 'aisle' | 'alpha';
+
+/** Discriminated page mode — replaces the two boolean constants USER_IS_LOGGED_IN / IS_READONLY. */
+export type PageMode = 'owner' | 'readonly' | 'anonymous';

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { User, onAuthStateChanged } from "@firebase/auth";
+import { authApp } from "@/lib/firebase/firebase-config";
+
+export interface AuthState {
+  user: User | null;
+  loading: boolean;
+}
+
+/**
+ * Hook that wraps Firebase onAuthStateChanged and returns the current
+ * auth state with a loading flag.
+ *
+ * Replaces the broken getUserUUID() helper in authentication.ts, which
+ * returned null immediately because onAuthStateChanged is asynchronous.
+ */
+export function useAuth(): AuthState {
+  const [state, setState] = useState<AuthState>({ user: null, loading: true });
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(authApp, (user) => {
+      setState({ user, loading: false });
+    });
+    return unsubscribe;
+  }, []);
+
+  return state;
+}

--- a/src/lib/firebase/shoppingLists.ts
+++ b/src/lib/firebase/shoppingLists.ts
@@ -1,0 +1,237 @@
+/**
+ * shoppingLists.ts
+ *
+ * Firestore CRUD operations for the shopping list feature.
+ * Uses @firebase/firestore (client SDK only — no firebase-admin).
+ *
+ * Collections:
+ *   shopping_lists/{listId}         — private, owner-only read/write
+ *   shared_list_views/{shareToken}  — public read, auth write; token IS the doc ID
+ */
+
+import {
+  collection,
+  doc,
+  addDoc,
+  getDoc,
+  getDocs,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+  query,
+  where,
+  orderBy,
+  limit,
+  writeBatch,
+  serverTimestamp,
+  Timestamp,
+} from "@firebase/firestore";
+import { firestoreDB } from "@/lib/firebase/firebase-config";
+import {
+  IShoppingList,
+  IShoppingListRecipe,
+  ISharedListView,
+} from "@/util/models";
+
+const LISTS_COLL = "shopping_lists";
+const SHARED_COLL = "shared_list_views";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function docToList(id: string, data: Record<string, unknown>): IShoppingList {
+  return { ...(data as IShoppingList), id };
+}
+
+function docToSharedView(data: Record<string, unknown>): ISharedListView {
+  return data as ISharedListView;
+}
+
+// ---------------------------------------------------------------------------
+// Read operations
+// ---------------------------------------------------------------------------
+
+/** Load the most recently updated list for a user. Returns null if none exist. */
+export async function getMostRecentList(uid: string): Promise<IShoppingList | null> {
+  const q = query(
+    collection(firestoreDB, LISTS_COLL),
+    where("ownerUid", "==", uid),
+    orderBy("updatedAt", "desc"),
+    limit(1)
+  );
+  const snap = await getDocs(q);
+  if (snap.empty) return null;
+  const d = snap.docs[0];
+  return docToList(d.id, d.data() as Record<string, unknown>);
+}
+
+/** Load all lists for a user (for the list switcher). */
+export async function getUserLists(uid: string): Promise<IShoppingList[]> {
+  const q = query(
+    collection(firestoreDB, LISTS_COLL),
+    where("ownerUid", "==", uid),
+    orderBy("updatedAt", "desc")
+  );
+  const snap = await getDocs(q);
+  return snap.docs.map(d => docToList(d.id, d.data() as Record<string, unknown>));
+}
+
+/** Load a single list by its document ID. */
+export async function getListById(listId: string): Promise<IShoppingList | null> {
+  const snap = await getDoc(doc(firestoreDB, LISTS_COLL, listId));
+  if (!snap.exists()) return null;
+  return docToList(snap.id, snap.data() as Record<string, unknown>);
+}
+
+/** Load a shared list view by share token. Returns null if token not found. */
+export async function getSharedList(shareToken: string): Promise<ISharedListView | null> {
+  const snap = await getDoc(doc(firestoreDB, SHARED_COLL, shareToken));
+  if (!snap.exists()) return null;
+  return docToSharedView(snap.data() as Record<string, unknown>);
+}
+
+// ---------------------------------------------------------------------------
+// Write operations
+// ---------------------------------------------------------------------------
+
+/** Create a new empty shopping list and return its document ID. */
+export async function createList(uid: string, name: string): Promise<string> {
+  const ref = await addDoc(collection(firestoreDB, LISTS_COLL), {
+    ownerUid: uid,
+    name,
+    recipes: [],
+    checkedIngredientIds: [],
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+  });
+  return ref.id;
+}
+
+/**
+ * Save (full overwrite) the current state of a shopping list.
+ * - If listId is provided → setDoc (full overwrite on existing doc)
+ * - If listId is undefined → addDoc (creates new document)
+ * Returns the document ID (new or existing).
+ *
+ * Also syncs the shared_list_views document if shareToken is present (UC-13b).
+ */
+export async function saveList(
+  payload: Omit<IShoppingList, "id" | "createdAt" | "updatedAt">,
+  listId?: string,
+  createdAt?: Timestamp
+): Promise<string> {
+  const data = {
+    ...payload,
+    updatedAt: serverTimestamp(),
+    createdAt: createdAt ?? serverTimestamp(),
+  };
+
+  let id: string;
+
+  if (listId) {
+    await setDoc(doc(firestoreDB, LISTS_COLL, listId), data);
+    id = listId;
+  } else {
+    const ref = await addDoc(collection(firestoreDB, LISTS_COLL), data);
+    id = ref.id;
+  }
+
+  // Auto-sync shared view (UC-13b) if this list is shared
+  if (payload.shareToken) {
+    await syncSharedView(payload.shareToken, {
+      name: payload.name,
+      recipes: payload.recipes,
+    });
+  }
+
+  return id;
+}
+
+/**
+ * Persist only the checked-item state.
+ * Called immediately on every check/uncheck (no debounce).
+ */
+export async function updateChecked(
+  listId: string,
+  checkedIngredientIds: string[]
+): Promise<void> {
+  await updateDoc(doc(firestoreDB, LISTS_COLL, listId), {
+    checkedIngredientIds,
+    updatedAt: serverTimestamp(),
+  });
+}
+
+/** Rename a list. */
+export async function renameList(listId: string, name: string): Promise<void> {
+  await updateDoc(doc(firestoreDB, LISTS_COLL, listId), {
+    name,
+    updatedAt: serverTimestamp(),
+  });
+}
+
+/**
+ * Delete a list document and optionally its associated shared view.
+ * Uses a batch so both deletes are atomic.
+ */
+export async function deleteList(listId: string, shareToken?: string): Promise<void> {
+  const batch = writeBatch(firestoreDB);
+  batch.delete(doc(firestoreDB, LISTS_COLL, listId));
+  if (shareToken) {
+    batch.delete(doc(firestoreDB, SHARED_COLL, shareToken));
+  }
+  await batch.commit();
+}
+
+// ---------------------------------------------------------------------------
+// Share operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a share token and atomically write:
+ *   - shopping_lists/{listId}          → { shareToken }
+ *   - shared_list_views/{shareToken}   → full public snapshot
+ *
+ * Returns the generated share token.
+ */
+export async function shareList(
+  list: IShoppingList,
+  ownerDisplayName: string
+): Promise<string> {
+  const token = crypto.randomUUID();
+  const batch = writeBatch(firestoreDB);
+
+  // Update the private list to record the token
+  batch.update(doc(firestoreDB, LISTS_COLL, list.id!), {
+    shareToken: token,
+    updatedAt: serverTimestamp(),
+  });
+
+  // Create the public shared view (token IS the document ID)
+  batch.set(doc(firestoreDB, SHARED_COLL, token), {
+    ownerUid: list.ownerUid,
+    ownerDisplayName,
+    listId: list.id,
+    name: list.name,
+    recipes: list.recipes,
+    updatedAt: serverTimestamp(),
+  });
+
+  await batch.commit();
+  return token;
+}
+
+/**
+ * Sync the public shared view when the owner saves their list (UC-13b).
+ * Called automatically by saveList when shareToken is present.
+ */
+export async function syncSharedView(
+  shareToken: string,
+  patch: { name: string; recipes: IShoppingListRecipe[] }
+): Promise<void> {
+  await updateDoc(doc(firestoreDB, SHARED_COLL, shareToken), {
+    name: patch.name,
+    recipes: patch.recipes,
+    updatedAt: serverTimestamp(),
+  });
+}

--- a/src/util/models.ts
+++ b/src/util/models.ts
@@ -1,5 +1,5 @@
-import {DocumentData} from "@firebase/firestore";
-import {TAisle, TDaysMenu, TFoodFamily, TPotProgram, TRecipeSection, TSeasons} from "@/util/constants";
+import {DocumentData, Timestamp} from "@firebase/firestore";
+import {TAisle, TDaysMenu, TFoodFamily, TMeasureUnits, TPotProgram, TRecipeSection, TSeasons} from "@/util/constants";
 
 type Enumerate<N extends number, Acc extends number[] = []> = Acc['length'] extends N
   ? Acc[number]
@@ -82,4 +82,50 @@ export interface IShoppingCart extends DocumentData{
   menu: IMenu;
   persons: number;
   ingredients: IRecipeIngredient[];
+}
+
+// --- Shopping List models ---
+
+/** Ingredient snapshot stored inside IShoppingListRecipe.
+ *  Captured at the moment a recipe is added to the list so consolidation
+ *  can run without re-fetching the recipe catalog on subsequent page loads. */
+export interface IShoppingListIngredient {
+  ingredientId: string;
+  name: string;
+  aisles: TAisle[];
+  quantity: number;
+  quantity_unit: TMeasureUnits;
+}
+
+/** Recipe entry inside a shopping list.
+ *  Includes a full ingredient snapshot (denormalized). */
+export interface IShoppingListRecipe {
+  recipeId: string;
+  name: string;
+  family: TFoodFamily;               // used to derive emoji via foodFamilies constant
+  basePortions: number;              // original recipe portions (for scaling)
+  portions: number;                  // user-adjusted portion count
+  ingredients: IShoppingListIngredient[];
+}
+
+export interface IShoppingList extends DocumentData {
+  id?: string;
+  ownerUid: string;
+  name: string;
+  recipes: IShoppingListRecipe[];
+  checkedIngredientIds: string[];    // flat array — supports arrayUnion / arrayRemove
+  shareToken?: string;               // present once the list has been shared
+  updatedAt: Timestamp;
+  createdAt: Timestamp;
+}
+
+export interface ISharedListView extends DocumentData {
+  // Document ID IS the shareToken (crypto.randomUUID()).
+  // allow read: if true is safe because the token is unguessable.
+  ownerUid: string;
+  ownerDisplayName: string;          // snapshot of display name at share time
+  listId: string;                    // back-reference to shopping_lists document
+  name: string;                      // snapshot of list name at share time
+  recipes: IShoppingListRecipe[];    // full denormalized ingredient snapshot
+  updatedAt: Timestamp;
 }

--- a/src/util/shoppingListUtils.ts
+++ b/src/util/shoppingListUtils.ts
@@ -1,0 +1,429 @@
+/**
+ * shoppingListUtils.ts
+ *
+ * Pure utility functions for the shopping list feature.
+ * No Firebase imports — fully unit-testable in isolation.
+ *
+ * Implements the consolidation rules from UC-6, UC-7, UC-8:
+ *   - grs + kg  → normalize to grams, display in kg if ≥ 1000 g
+ *   - ml  + lt  → normalize to ml,    display in lt if ≥ 1000 ml
+ *   - same non-metric unit (cdta/cda/tz) → sum as plain numbers
+ *   - different non-metric units          → display separately on one line
+ *   - unidad                              → sum as integers
+ *   - incompatible groups                → "300 g + 2 unidades"
+ */
+
+import { IRecipe, IShoppingListIngredient, IShoppingListRecipe, IShoppingList } from "@/util/models";
+import { foodFamilies, marketAisles, TMeasureUnits } from "@/util/constants";
+import { ShoppingAisle, ShoppingIngredient, ShoppingRecipe, RecipeIngredientDetail, SavedList, SortMode } from "@/components/Shopping/types";
+
+// ---------------------------------------------------------------------------
+// Unit conversion helpers
+// ---------------------------------------------------------------------------
+
+/** Convert a mass quantity to grams. Returns null for non-mass units. */
+export function toGrams(qty: number, unit: TMeasureUnits): number | null {
+  if (unit === "grs") return qty;
+  if (unit === "kg") return qty * 1000;
+  return null;
+}
+
+/** Convert a volume quantity to millilitres. Returns null for non-volume units. */
+export function toMl(qty: number, unit: TMeasureUnits): number | null {
+  if (unit === "ml") return qty;
+  if (unit === "lt") return qty * 1000;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+/** Format a total-gram value for display: < 1000 → "NNN g", ≥ 1000 → "N.Nkg" */
+export function formatMass(totalGrams: number): string {
+  if (totalGrams < 1000) {
+    return `${Math.round(totalGrams)} g`;
+  }
+  const kg = totalGrams / 1000;
+  // Trim trailing .0 for clean display
+  const formatted = kg % 1 === 0 ? `${kg}` : kg.toFixed(1);
+  return `${formatted} kg`;
+}
+
+/** Format a total-ml value for display: < 1000 → "NNN ml", ≥ 1000 → "N.Nlt" */
+export function formatVolume(totalMl: number): string {
+  if (totalMl < 1000) {
+    return `${Math.round(totalMl)} ml`;
+  }
+  const lt = totalMl / 1000;
+  const formatted = lt % 1 === 0 ? `${lt}` : lt.toFixed(1);
+  return `${formatted} lt`;
+}
+
+/** Single source of truth for quantity + unit display strings. */
+export function formatQty(qty: number, unit: TMeasureUnits): string {
+  const rounded = qty % 1 === 0 ? qty : parseFloat(qty.toFixed(2));
+  switch (unit) {
+    case "grs":   return `${rounded} g`;
+    case "kg":    return `${rounded} kg`;
+    case "ml":    return `${rounded} ml`;
+    case "lt":    return `${rounded} lt`;
+    case "cdta":  return `${rounded} cdta${rounded !== 1 ? "s" : ""}`;
+    case "cda":   return `${rounded} cda${rounded !== 1 ? "s" : ""}`;
+    case "tz":    return `${rounded} tz`;
+    case "unidad":return `${rounded} unidad${rounded !== 1 ? "es" : ""}`;
+    case "-":     return "-";
+    default:      return `${rounded} ${unit}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scaling
+// ---------------------------------------------------------------------------
+
+/** Scale an ingredient quantity by the portions ratio. */
+export function scaleIngredient(
+  ingredient: IShoppingListIngredient,
+  targetPortions: number,
+  basePortions: number
+): { qty: number; unit: TMeasureUnits } {
+  const multiplier = basePortions > 0 ? targetPortions / basePortions : 1;
+  return {
+    qty: ingredient.quantity * multiplier,
+    unit: ingredient.quantity_unit,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Consolidation map
+// ---------------------------------------------------------------------------
+
+interface Contribution {
+  qty: number;
+  unit: TMeasureUnits;
+}
+
+interface ConsolidationEntry {
+  ingredientId: string;
+  name: string;
+  aisles: string[];
+  contributions: Contribution[];
+}
+
+/**
+ * Build a map of ingredientId → ConsolidationEntry by iterating over every
+ * recipe in the list and scaling each ingredient by the portions ratio.
+ * Works entirely from the stored IShoppingListRecipe snapshot — no
+ * additional Firestore reads needed.
+ */
+export function buildConsolidationMap(
+  listRecipes: IShoppingListRecipe[]
+): Map<string, ConsolidationEntry> {
+  const map = new Map<string, ConsolidationEntry>();
+
+  for (const recipe of listRecipes) {
+    for (const ingredient of recipe.ingredients) {
+      const scaled = scaleIngredient(ingredient, recipe.portions, recipe.basePortions);
+      const key = ingredient.ingredientId || ingredient.name.toLowerCase().trim();
+
+      const existing = map.get(key);
+      if (existing) {
+        existing.contributions.push(scaled);
+      } else {
+        map.set(key, {
+          ingredientId: key,
+          name: ingredient.name,
+          aisles: ingredient.aisles,
+          contributions: [scaled],
+        });
+      }
+    }
+  }
+
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Quantity resolution — UC-6, UC-7, UC-8
+// ---------------------------------------------------------------------------
+
+const MASS_UNITS: TMeasureUnits[] = ["grs", "kg"];
+const VOLUME_UNITS: TMeasureUnits[] = ["ml", "lt"];
+const CULINARY_UNITS: TMeasureUnits[] = ["cdta", "cda", "tz"];
+
+function unitGroup(unit: TMeasureUnits): "mass" | "volume" | "culinary" | "count" | "taste" {
+  if (MASS_UNITS.includes(unit)) return "mass";
+  if (VOLUME_UNITS.includes(unit)) return "volume";
+  if (CULINARY_UNITS.includes(unit)) return "culinary";
+  if (unit === "unidad") return "count";
+  return "taste";
+}
+
+/**
+ * Resolve a list of contributions into a single display string.
+ *
+ * Rules (applied in priority order):
+ *  1. All same unit                          → sum → formatQty
+ *  2. All mass units (grs/kg)               → sum as grams → formatMass
+ *  3. All volume units (ml/lt)              → sum as ml → formatVolume
+ *  4. All same culinary unit (cdta/cda/tz)  → sum → formatQty
+ *  5. Mixed groups                           → per-group strings joined with " + "
+ *     Priority order: mass > volume > culinary > count > taste
+ */
+export function resolveQty(contributions: Contribution[]): string {
+  if (contributions.length === 0) return "-";
+
+  const allSameUnit = contributions.every(c => c.unit === contributions[0].unit);
+
+  if (allSameUnit) {
+    const total = contributions.reduce((s, c) => s + c.qty, 0);
+    return formatQty(total, contributions[0].unit);
+  }
+
+  const groups = new Map<string, Contribution[]>();
+  for (const c of contributions) {
+    const g = unitGroup(c.unit);
+    if (!groups.has(g)) groups.set(g, []);
+    groups.get(g)!.push(c);
+  }
+
+  const parts: string[] = [];
+  const ORDER = ["mass", "volume", "culinary", "count", "taste"] as const;
+
+  for (const g of ORDER) {
+    const cs = groups.get(g);
+    if (!cs) continue;
+
+    if (g === "mass") {
+      const totalGrams = cs.reduce((s, c) => s + (toGrams(c.qty, c.unit) ?? 0), 0);
+      parts.push(formatMass(totalGrams));
+    } else if (g === "volume") {
+      const totalMl = cs.reduce((s, c) => s + (toMl(c.qty, c.unit) ?? 0), 0);
+      parts.push(formatVolume(totalMl));
+    } else if (g === "culinary") {
+      // Try to sum within each culinary sub-unit
+      const byUnit = new Map<TMeasureUnits, number>();
+      for (const c of cs) {
+        byUnit.set(c.unit, (byUnit.get(c.unit) ?? 0) + c.qty);
+      }
+      for (const [unit, total] of byUnit) {
+        parts.push(formatQty(total, unit));
+      }
+    } else if (g === "count") {
+      const total = cs.reduce((s, c) => s + c.qty, 0);
+      parts.push(formatQty(total, "unidad"));
+    } else {
+      // taste ("-") — just show once
+      parts.push("-");
+    }
+  }
+
+  return parts.join(" + ");
+}
+
+// ---------------------------------------------------------------------------
+// Aisle building — final output for the UI
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the ShoppingAisle[] used by the page to render the ingredient list.
+ * Replaces makeStubAisles().
+ *
+ * sortMode 'aisle': grouped by supermarket aisle in marketAisles order.
+ * sortMode 'alpha': single virtual aisle with all items sorted A-Z (es locale).
+ */
+export function buildAisles(
+  listRecipes: IShoppingListRecipe[],
+  checkedIds: Set<string>,
+  sortMode: SortMode = "aisle"
+): ShoppingAisle[] {
+  const consolidationMap = buildConsolidationMap(listRecipes);
+
+  // Convert each entry to a ShoppingIngredient
+  const items: (ShoppingIngredient & { aisleId: string })[] = [];
+  for (const entry of consolidationMap.values()) {
+    const qty = resolveQty(entry.contributions);
+    // Use first aisle, fallback to 'none'
+    const aisleId = (entry.aisles?.[0] as string) ?? "none";
+    items.push({
+      id: entry.ingredientId,
+      name: entry.name,
+      qty,
+      checked: checkedIds.has(entry.ingredientId),
+      aisleId,
+    });
+  }
+
+  if (sortMode === "alpha") {
+    const sorted = [...items].sort((a, b) =>
+      a.name.localeCompare(b.name, "es", { sensitivity: "base" })
+    );
+    return [
+      {
+        id: "alpha",
+        icon: "🔤",
+        name: "Todos los ingredientes",
+        items: sorted.map(({ aisleId: _a, ...rest }) => rest),
+      },
+    ];
+  }
+
+  // Group by aisle, ordered by marketAisles index
+  const aisleMap = new Map<string, ShoppingIngredient[]>();
+
+  for (const item of items) {
+    const { aisleId, ...ingredient } = item;
+    const key = aisleId in VALID_AISLE_IDS ? aisleId : "none";
+    if (!aisleMap.has(key)) aisleMap.set(key, []);
+    aisleMap.get(key)!.push(ingredient);
+  }
+
+  const result: ShoppingAisle[] = [];
+  for (const aisleDef of marketAisles) {
+    const aisleItems = aisleMap.get(aisleDef.id);
+    if (!aisleItems || aisleItems.length === 0) continue;
+
+    // Sort items within each aisle alphabetically
+    aisleItems.sort((a, b) =>
+      a.name.localeCompare(b.name, "es", { sensitivity: "base" })
+    );
+
+    result.push({
+      id: aisleDef.id,
+      icon: aisleDef.icon ?? "🛒",
+      name: aisleDef.name,
+      items: aisleItems,
+    });
+  }
+
+  return result;
+}
+
+// Set of valid aisle IDs for fast lookup (avoids falling through to "none" for valid ids)
+const VALID_AISLE_IDS: Record<string, true> = Object.fromEntries(
+  marketAisles.map(a => [a.id, true as const])
+);
+
+// ---------------------------------------------------------------------------
+// RecipeIngModal detail helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive RecipeIngredientDetail[] for the RecipeIngModal from a stored
+ * IShoppingListRecipe. Replaces STUB_RECIPE_DETAILS.
+ */
+export function getRecipeIngredientDetails(
+  recipe: IShoppingListRecipe
+): RecipeIngredientDetail[] {
+  return recipe.ingredients.map(ing => {
+    const scaled = scaleIngredient(ing, recipe.portions, recipe.basePortions);
+    return {
+      name: ing.name,
+      qty: formatQty(scaled.qty, scaled.unit),
+      aisle: ing.aisles?.[0] ?? "none",
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Google Keep export
+// ---------------------------------------------------------------------------
+
+/** Format aisles as Google Keep checkbox text (UC-14). */
+export function buildKeepText(aisles: ShoppingAisle[]): string {
+  return aisles
+    .flatMap(a => a.items)
+    .map(item => `[ ] ${item.qty} ${item.name}`)
+    .join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Persistence helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert an IRecipe (from the autocomplete selection) into an
+ * IShoppingListRecipe with a full ingredient snapshot.
+ * Called when the user adds a recipe from the selector.
+ */
+export function recipeToShoppingListRecipe(
+  recipe: IRecipe,
+  portions: number
+): IShoppingListRecipe {
+  return {
+    recipeId: recipe.id ?? "",
+    name: recipe.name,
+    family: recipe.family,
+    basePortions: recipe.portions,
+    portions,
+    ingredients: (recipe.ingredients_list ?? []).map(ri => ({
+      ingredientId: ri.ingredient.id ?? ri.ingredient.name.toLowerCase().trim(),
+      name: ri.ingredient.name,
+      aisles: ri.ingredient.aisles ?? [],
+      quantity: ri.quantity,
+      quantity_unit: ri.quantity_unit as TMeasureUnits,
+    })),
+  };
+}
+
+/**
+ * Build the Firestore payload from current page state.
+ * Does NOT include id, createdAt, updatedAt (those are set by the Firebase layer).
+ */
+export function buildListPayload(
+  name: string,
+  ownerUid: string,
+  listRecipes: IShoppingListRecipe[],
+  checkedIds: Set<string>,
+  shareToken?: string
+): Omit<IShoppingList, "id" | "createdAt" | "updatedAt"> {
+  const payload: Omit<IShoppingList, "id" | "createdAt" | "updatedAt"> = {
+    name,
+    ownerUid,
+    recipes: listRecipes,
+    checkedIngredientIds: [...checkedIds],
+  };
+  if (shareToken) payload.shareToken = shareToken;
+  return payload;
+}
+
+/**
+ * Hydrate page state from a saved IShoppingList or ISharedListView.
+ * Returns the ShoppingRecipe[] (for UI) and checkedIngredientIds Set.
+ * Does not require a recipe cache — all data is in the stored snapshot.
+ */
+export function hydrateSavedList(list: {
+  recipes: IShoppingListRecipe[];
+  checkedIngredientIds?: string[];
+}): {
+  listRecipes: IShoppingListRecipe[];
+  selRecipes: ShoppingRecipe[];
+  checkedIngredientIds: Set<string>;
+} {
+  const selRecipes: ShoppingRecipe[] = list.recipes.map(r => ({
+    id: r.recipeId,
+    name: r.name,
+    emoji: foodFamilies.find(f => f.id === r.family)?.icon ?? "🍽️",
+    portions: r.portions,
+    basePortions: r.basePortions,
+  }));
+
+  return {
+    listRecipes: list.recipes,
+    selRecipes,
+    checkedIngredientIds: new Set(list.checkedIngredientIds ?? []),
+  };
+}
+
+/**
+ * Convert an IShoppingList[] to the SavedList[] shape used by the
+ * list switcher modal.
+ */
+export function toSavedLists(lists: IShoppingList[]): SavedList[] {
+  return lists.map(l => ({
+    id: l.id ?? "",
+    name: l.name,
+    shortName: l.name.length > 15 ? l.name.slice(0, 14) + "…" : l.name,
+    itemCount: l.recipes.length,
+  }));
+}


### PR DESCRIPTION
## Contexto

Esta PR es la segunda parte de la feature de lista de compras, construida sobre la UI entregada en #6.

Implementa toda la capa de datos, autenticación, algoritmo de consolidación de ingredientes y el wire-up completo de la página `/shopping`.

---

## Qué cambia

### Firestore
- **`firestore.rules`** — reglas para dos nuevas colecciones:
  - `shopping_lists/{listId}` — lectura/escritura sólo para el dueño autenticado
  - `shared_list_views/{shareToken}` — lectura pública (el token como document ID actúa como capability key), escritura autenticada
- **`firestore.indexes.json`** — índice compuesto en `shopping_lists(ownerUid ASC, updatedAt DESC)` para la query de "lista más reciente" y el list switcher

### Modelos (`src/util/models.ts`)
Cuatro interfaces nuevas:
- `IShoppingListIngredient` — snapshot de ingrediente capturado al añadir una receta
- `IShoppingListRecipe` — receta dentro de la lista, con snapshot completo de ingredientes (desnormalizado para evitar fetch adicionales en carga)
- `IShoppingList` — documento Firestore de la lista privada
- `ISharedListView` — documento público accesible por token

### Hook de autenticación (`src/hooks/useAuth.ts`)
Reemplaza el bug en `getUserUUID()` (retornaba `null` inmediatamente porque `onAuthStateChanged` es async). El nuevo hook expone `{ user, loading }` correctamente.

### Algoritmo de consolidación (`src/util/shoppingListUtils.ts`)
Funciones puras, sin Firebase, 100% testables:
- Normalización de unidades: `grs`/`kg` → gramos; `ml`/`lt` → mililitros
- `resolveQty` implementa UC-6/7/8: suma unidades compatibles, formatea al rango correcto (ej. `500g + 1kg → 1.5 kg`), muestra incompatibles en una línea (`300 g + 2 unidades`)
- `buildAisles` — reemplaza `makeStubAisles()`: agrupa por pasillo respetando el orden de `marketAisles`, o modo alfa con un único pasillo
- `hydrateSavedList` — deserializa un `IShoppingList` a estado de página sin necesitar el catálogo de recetas (los ingredientes están en el snapshot)
- `recipeToShoppingListRecipe` — captura el snapshot al momento de añadir una receta desde el autocomplete
- Helpers: `buildKeepText` (formato Google Keep `[ ] qty nombre`), `buildListPayload`, `toSavedLists`

### Módulo Firebase (`src/lib/firebase/shoppingLists.ts`)
CRUD completo + share:
- `getMostRecentList`, `getUserLists`, `getListById`, `getSharedList`
- `createList`, `saveList` (full overwrite + auto-sync de shared view si shareToken presente — UC-13b)
- `updateChecked` — persiste inmediatamente el estado de tachado sin debounce
- `shareList` — genera `crypto.randomUUID()` como token, batch write atómico en `shopping_lists` y `shared_list_views`
- `syncSharedView` — actualiza el snapshot público cuando el dueño guarda

### Componentes actualizados
- `Shopping/types.ts` — `PageMode = 'owner' | 'readonly' | 'anonymous'` reemplaza los dos booleanos hardcodeados
- `ActionBar` — nuevo prop `canSave`/`onSave`; muestra botón "Guardar" cuando hay cambios pendientes
- `RecipeSelector`, `ListHeader`, `ListSwitcherModal`, `RecipeIngModal`, `RecipeChip` — eliminados imports de stubs, reemplazados por props reales
- `stubs.ts` — eliminado

### Página `/shopping` (`src/app/shopping/page.tsx`)
Wire-up completo:
- `useAuth` + `useSearchParams` determinan `pageMode` ('owner' | 'readonly' | 'anonymous')
- Modo readonly detectado por `?token=<shareToken>` en URL (UC-13)
- `listRecipes: IShoppingListRecipe[]` como estado primario; `selRecipes` y `aisles` son derivados via `useMemo`
- Carga el catálogo de recetas en paralelo (para el autocomplete) y la lista guardada (desde snapshot, sin bloquear)
- Botón "Guardar" explícito con dirty tracking
- Check-off persistido inmediatamente en Firestore para usuarios dueños; in-memory para anónimos/readonly
- Flujo completo: nueva lista, cambio de lista, compartir, limpiar
- Wrapper `<Suspense>` para `useSearchParams` en Next.js 15

### Docs
- `docs/usecases/shopping-list.md` — URL de share actualizada a `?token=<shareToken>`, UC-13b añadido, sección de consideraciones técnicas

### Ruta habilitada
- `Base.tsx` — `/shopping` ahora `enabled: true`, `inBottomBar: true`

---

## Arquitectura de share (decisión clave)

Firestore no puede verificar "el cliente conoce un valor" a nivel de reglas de seguridad a menos que ese valor esté en el path del documento. Por eso `shared_list_views/{shareToken}` usa el token como document ID: `allow read: if true` es seguro porque el token es un UUID no adivinable.

Cuando el dueño guarda, un `writeBatch` actualiza atómicamente `shopping_lists/{listId}` y `shared_list_views/{shareToken}` — cualquier destinatario que refresque el link ve el estado actual inmediatamente.

---

## Pendiente antes de producción

```bash
firebase deploy --only firestore   # sube rules + index al proyecto camino-del-nom
```

---

## Smoke test manual

1. `/shopping` anónimo → empty state + banner de login
2. Login → carga última lista automáticamente
3. Añadir receta → ingredientes agrupados por pasillo con unidades consolidadas
4. Ajustar porciones → cantidades escalan correctamente
5. Tachar ítem → survives reload (persistido en Firestore)
6. Guardar → botón desaparece, snack "Lista guardada"
7. Compartir → URL generada; abrir en incógnito → modo readonly, tachado funciona in-memory
8. `/shopping?token=<token>` directo → modo readonly, sin controles de edición