### PR TITLE
fix: shopping list UI and data loading fixes

### DIFF
--- a/docs/usecases/shopping-list.md
+++ b/docs/usecases/shopping-list.md
@@ -216,3 +216,35 @@ Recipients can check items off while shopping, but that state is held **in-memor
 | Owner renames the list | Reflected in `shared_list_views.listName` on next save |
 | Owner wants to revoke access | Delete the `shared_list_views/{shareToken}` document; the link 404s immediately |
 | Owner generates a new share link | A new `shareToken` is created; old token document can be deleted or left to expire |
+
+---
+
+## Known issues & fixes
+
+### BUG-01 — Recipe chips overflow horizontally on mobile (fixed in PR #8)
+
+**Symptom:** On small screens or narrow windows, selected recipe chips in the `RecipeSelector` formed a single horizontal row with hidden overflow scroll. This made chips unreachable and hid the remove button on the last chip.
+
+**Root cause:** The chip container had `flexWrap: { xs: 'nowrap', md: 'wrap' }` combined with `overflowX: 'auto'`, deliberately enabling horizontal scroll on mobile. This was a design decision that turned out to degrade usability.
+
+**Fix:** Replaced with `flexWrap: 'wrap'` on all breakpoints, removing the horizontal scroll entirely. Chips now wrap to new lines consistently regardless of screen size.
+
+**File changed:** `src/components/Shopping/organisms/RecipeSelector.tsx`
+
+---
+
+### BUG-02 — Saved lists not appearing in the list switcher (fixed in PR #8)
+
+**Symptom:** Logged-in users opened the "Mi lista" dropdown and saw no lists, even when lists existed in Firestore.
+
+**Root cause:** `getMostRecentList` and `getUserLists` in `shoppingLists.ts` combined `where("ownerUid", "==", uid)` with `orderBy("updatedAt", "desc")`. Firestore requires a **composite index** for queries that filter on one field and sort on a different one. That index was never deployed (the `firebase deploy` step failed with a 401 auth error during initial setup, and only the security rules were added manually). Without the index, both queries threw a Firestore error at runtime.
+
+The error was silently swallowed because the `Promise.all` in `page.tsx` had no `.catch()`, so `allLists` stayed `[]` and the switcher appeared empty with no feedback.
+
+**Fix (two parts):**
+1. Removed `orderBy` from both Firestore queries and replaced with client-side sorting by `updatedAt`. A plain `where` on a single field uses Firestore's automatic single-field index — no composite index required.
+2. Added `.catch(err => console.error(...))` to the `Promise.all` so future Firestore errors are visible in the browser console.
+
+**Files changed:** `src/lib/firebase/shoppingLists.ts`, `src/app/shopping/page.tsx`
+
+**Note on composite indexes:** Firestore security rules and composite indexes are deployed separately. Rules control access; indexes control query capability. Both must be present for a query to succeed. The `firebase deploy --only firestore` command deploys both from `firestore.rules` and `firestore.indexes.json` respectively — deploying only rules leaves indexes untouched.

--- a/src/app/shopping/page.tsx
+++ b/src/app/shopping/page.tsx
@@ -164,7 +164,7 @@ function ShoppingPageContent() {
         const { listRecipes: lr, checkedIngredientIds } = hydrateSavedList(recent);
         setListRecipes(lr);
         setCheckedIds(checkedIngredientIds);
-      });
+      }).catch(err => console.error("[Shopping] Failed to load lists:", err));
     }
     // pageMode === 'anonymous': stays empty, no-op
   }, [authLoading, user, pageMode, shareToken]);

--- a/src/components/Shopping/organisms/RecipeSelector.tsx
+++ b/src/components/Shopping/organisms/RecipeSelector.tsx
@@ -64,12 +64,9 @@ export function RecipeSelector({ availableRecipes, selectedRecipes, onAdd, onRem
           sx={{
             display: 'flex',
             gap: 1,
-            overflowX: 'auto',
             pt: 1.25,
             pb: 0.25,
-            flexWrap: { xs: 'nowrap', md: 'wrap' },
-            scrollbarWidth: 'none',
-            '&::-webkit-scrollbar': { display: 'none' },
+            flexWrap: 'wrap',
           }}
         >
           {selectedRecipes.map(r => (

--- a/src/lib/firebase/shoppingLists.ts
+++ b/src/lib/firebase/shoppingLists.ts
@@ -20,8 +20,6 @@ import {
   deleteDoc,
   query,
   where,
-  orderBy,
-  limit,
   writeBatch,
   serverTimestamp,
   Timestamp,
@@ -56,13 +54,17 @@ function docToSharedView(data: Record<string, unknown>): ISharedListView {
 export async function getMostRecentList(uid: string): Promise<IShoppingList | null> {
   const q = query(
     collection(firestoreDB, LISTS_COLL),
-    where("ownerUid", "==", uid),
-    orderBy("updatedAt", "desc"),
-    limit(1)
+    where("ownerUid", "==", uid)
   );
   const snap = await getDocs(q);
   if (snap.empty) return null;
-  const d = snap.docs[0];
+  // Sort client-side — avoids requiring a composite index on (ownerUid, updatedAt)
+  const sorted = snap.docs.sort((a, b) => {
+    const aMs = (a.data().updatedAt as Timestamp)?.toMillis() ?? 0;
+    const bMs = (b.data().updatedAt as Timestamp)?.toMillis() ?? 0;
+    return bMs - aMs;
+  });
+  const d = sorted[0];
   return docToList(d.id, d.data() as Record<string, unknown>);
 }
 
@@ -70,11 +72,17 @@ export async function getMostRecentList(uid: string): Promise<IShoppingList | nu
 export async function getUserLists(uid: string): Promise<IShoppingList[]> {
   const q = query(
     collection(firestoreDB, LISTS_COLL),
-    where("ownerUid", "==", uid),
-    orderBy("updatedAt", "desc")
+    where("ownerUid", "==", uid)
   );
   const snap = await getDocs(q);
-  return snap.docs.map(d => docToList(d.id, d.data() as Record<string, unknown>));
+  // Sort client-side — avoids requiring a composite index on (ownerUid, updatedAt)
+  return snap.docs
+    .sort((a, b) => {
+      const aMs = (a.data().updatedAt as Timestamp)?.toMillis() ?? 0;
+      const bMs = (b.data().updatedAt as Timestamp)?.toMillis() ?? 0;
+      return bMs - aMs;
+    })
+    .map(d => docToList(d.id, d.data() as Record<string, unknown>));
 }
 
 /** Load a single list by its document ID. */


### PR DESCRIPTION
## Summary

- **Recipe chips wrap vertically on all screen sizes** — replaced horizontal scroll on mobile with `flexWrap: 'wrap'`, matching the desktop behaviour across all breakpoints.
- **Saved lists now load correctly in the list switcher** — the previous queries used `orderBy("updatedAt")` alongside `where("ownerUid")`, which requires a composite Firestore index that was never deployed. Replaced with client-side sorting to eliminate the index requirement entirely. Also added `.catch()` to surface any future Firestore errors in the console instead of swallowing them silently.

## Test plan

- [ ] Open `/shopping` on a narrow window — recipe chips should wrap to new lines instead of scrolling horizontally
- [ ] Log in and open the "Mi lista" dropdown — all saved lists should appear
- [ ] Switch between lists — content loads correctly
- [ ] Create a new list — appears in the switcher immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)