### PR TITLE
docs: shopping list status badges and architectural decision records

### DIFF
--- a/.claude/hooks/doc-check.ps1
+++ b/.claude/hooks/doc-check.ps1
@@ -1,0 +1,15 @@
+# Runs at the end of each Claude session.
+# Warns if source files were modified but docs/ was not touched.
+
+$srcChanged = git status --porcelain 2>$null |
+    Where-Object { $_ -match '^\s*[MAD?]\s+src/' }
+
+$docsChanged = git status --porcelain 2>$null |
+    Where-Object { $_ -match '^\s*[MAD?]\s+docs/' }
+
+if ($srcChanged -and -not $docsChanged) {
+    Write-Host ""
+    Write-Host "doc-check: src/ has uncommitted changes but docs/ does not." -ForegroundColor Yellow
+    Write-Host "           If this session implemented or changed a feature, update its use case doc." -ForegroundColor Yellow
+    Write-Host ""
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -File .claude/hooks/doc-check.ps1"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# FoodPlanerReact — Claude Code Instructions
+
+## Project overview
+
+A Next.js + Firebase app for meal planning. Users can create recipes, plan weekly menus,
+and generate shopping lists. Deployed on GitHub Pages under the subpath `/FoodPlanerReact`.
+
+Key paths: `src/app/` (pages), `src/components/` (UI), `src/lib/firebase/` (data layer),
+`docs/usecases/` (feature specs), `docs/decisions/` (ADRs).
+
+---
+
+## Feature documentation practice
+
+These rules apply whenever we are building or modifying a named feature.
+
+### Starting a feature
+
+1. If the user has not stated a **why**, ask for it before any design work.
+   One sentence is enough. Do not proceed until you have it.
+2. Check `docs/usecases/` for an existing doc on this feature before creating a new one.
+3. Use `docs/templates/uc-template.md` as the starting structure.
+4. Draft the UC list and show it to the user **before writing any files**.
+   Scope is most likely to be wrong at this moment — catch it here.
+5. Once confirmed, create `docs/usecases/<feature-slug>.md`. All UCs start as `PLANNED`.
+
+### During implementation
+
+- When a UC is implemented, update its status to `DONE` or
+  `PARTIAL — <one line on what is missing>` immediately — not at the end.
+- When you fix a bug that was not in the original design, add a BUG entry to the doc
+  at the same moment you write the fix. Root cause is freshest right then.
+- When you make an architectural decision whose WHY is not obvious from the code,
+  create an ADR in `docs/decisions/` using `docs/templates/adr-template.md` before
+  moving on. Rule of thumb: if a competent developer would ask "why did they do it
+  this way?", it needs an ADR.
+- Add a `**See:** ADR-NN` line to any UC governed by a new ADR.
+
+### Wrapping up
+
+When the user declares a feature done or asks to open a PR, do a final doc pass:
+- Verify all UC statuses reflect actual code (read the files, don't assume).
+- Check for undocumented architectural decisions.
+- Add a `### Known gaps` section under Notes for anything deferred.
+
+### Session continuity
+
+At the start of any session that touches an existing feature, read its doc first and
+flag any UC whose status looks stale given recent commits. Do not wait to be asked.
+
+---
+
+## ADR conventions
+
+- Files live in `docs/decisions/ADR-NN-slug.md`.
+- Number sequentially from the highest existing ADR.
+- Status values: `Accepted` | `Deprecated` | `Superseded by ADR-NN`.
+- Only write an ADR when the WHY cannot be inferred from the code alone.
+  Do not document obvious or conventional choices.
+- The `⚠️` prefix on a consequence bullet means: if this changes, revisit the ADR.
+
+---
+
+## Code conventions
+
+- TypeScript strict mode is on.
+- Firebase basePath is `/FoodPlanerReact` — never generate bare share URLs;
+  always use the full production URL or `window.location.origin + basePath`.
+- Firestore security rules and indexes are deployed separately via
+  `firebase deploy --only firestore`. Deploying only rules leaves indexes untouched.
+- Anonymous users have no Firestore write path — design accordingly.

--- a/docs/decisions/ADR-01-share-token-as-document-id.md
+++ b/docs/decisions/ADR-01-share-token-as-document-id.md
@@ -1,0 +1,28 @@
+---
+id: ADR-01
+status: Accepted
+date: 2026-05-17
+---
+
+## ADR-01 — Share token as Firestore document ID
+
+### Context
+Anonymous (unauthenticated) recipients must be able to open a share link and read the shopping list, while the owner's private `shopping_lists` collection must remain inaccessible to anyone else. Firestore security rules can inspect `resource.data`, `request.auth`, and the document path, but **cannot inspect query parameters or verify that the client "knows" a value at read time** unless that value is part of the document path. Storing a `shareToken` as a field on a document would force one of two bad choices: open the whole collection to public read (and let attackers enumerate IDs), or require an auth path that defeats the purpose of a public link.
+
+### Decision
+The share token is generated via `crypto.randomUUID()` and used directly as the document ID of `shared_list_views/{shareToken}`. The companion `allow get, read: if true` rule on that collection is safe because retrieval requires possession of the unguessable UUID. The private `shopping_lists/{listId}` collection keeps owner-only rules and is never exposed.
+
+### Consequences
+- Public access works without an auth round-trip; share links open instantly for recipients.
+- Security rules stay trivially auditable (`allow read: if true` is correct because the path itself is the credential).
+- The private list stays fully isolated — sharing copies a snapshot rather than relaxing rules on the source.
+- ⚠️ Revoking a share requires deleting the `shared_list_views/{token}` document; there is no expiry, rotation, or audit log of who fetched a link.
+- ⚠️ UUID entropy (122 bits) is the entire security boundary — if a token ever leaks (logs, analytics, referer headers), anyone who sees it has permanent read access until manually revoked.
+- ⚠️ Cannot enumerate "all shares for a user" by querying `shared_list_views` because there is no index on `ownerUid` (and adding one would weaken the model). Owners only know about shares whose token is recorded in their `shopping_lists/{listId}.shareToken` field.
+
+### Related
+- UC-13 (Share list)
+- UC-13b (Shared list stays in sync) — depends on this collection layout
+- ADR-02 (Batch write for owner-save + share sync)
+- ADR-03 (Recipient check-off state held in memory only)
+- `firestore.rules` lines 20–27

--- a/docs/decisions/ADR-02-batch-write-owner-save-and-share-sync.md
+++ b/docs/decisions/ADR-02-batch-write-owner-save-and-share-sync.md
@@ -1,0 +1,24 @@
+---
+id: ADR-02
+status: Accepted
+date: 2026-05-17
+---
+
+## ADR-02 — Batch write for owner-save + share sync
+
+### Context
+When the owner saves a shared list, two documents must reflect the new state: the private canonical `shopping_lists/{listId}` and the public snapshot `shared_list_views/{shareToken}`. Doing these as two separate, unrelated writes risks a torn state — a recipient refreshing between the two writes would see stale data, or worse, see a snapshot that references recipes the owner has since removed. Polling, webhooks, and Cloud Functions were rejected as over-engineering for a 1-write-per-save use case that already happens client-side.
+
+### Decision
+Sharing (`shareList` in `src/lib/firebase/shoppingLists.ts`) uses a single Firestore `writeBatch` that both updates the private document to record the token and creates the public `shared_list_views/{token}` document atomically. The subsequent sync on save is implemented by `saveList` calling `syncSharedView` whenever `shareToken` is present on the payload.
+
+### Consequences
+- The initial share (`shareList`) is atomic — the token field on the private list and the public snapshot land together or not at all.
+- No background infrastructure (Cloud Functions, schedulers) is needed; the client owns the sync.
+- ⚠️ `saveList` performs the save and the share-sync as **two sequential awaits** rather than a single batch (see `saveList` body: `setDoc`/`addDoc` then `await syncSharedView`). If the second write fails the canonical list is already saved and the shared view goes stale until the next successful save. UC-13b's "atomic" promise is therefore only approximate today; reconciling this is tracked under UC-13b status `PARTIAL`.
+- ⚠️ All writes happen from the client; a malicious owner could in theory submit divergent payloads for the two documents. Security rules mitigate but do not eliminate this — they validate `ownerUid` matches but do not cross-check recipe contents.
+
+### Related
+- UC-13 (Share list) — initial share is fully batched
+- UC-13b (Shared list stays in sync) — currently PARTIAL, not single-batch
+- ADR-01 (Share token as document ID) — defines the two-document layout this ADR keeps in sync

--- a/docs/decisions/ADR-03-recipient-checkoff-in-memory-only.md
+++ b/docs/decisions/ADR-03-recipient-checkoff-in-memory-only.md
@@ -1,0 +1,28 @@
+---
+id: ADR-03
+status: Accepted
+date: 2026-05-17
+---
+
+## ADR-03 — Recipient check-off state held in memory only
+
+### Context
+Multiple recipients may open the same share link and check off items concurrently while shopping. Persisting their check-off state to Firestore would require either (a) writeable anonymous access to `shared_list_views`, expanding the attack surface to anyone who knows the token, or (b) per-recipient subdocuments keyed by some client-generated identity, which introduces merge conflicts when two people check different items in the same row. Neither cost is justified for a shared grocery session that ends when the shopping is done.
+
+### Decision
+In `src/app/shopping/page.tsx`, `toggleIngredient` only calls `updateChecked` when `pageMode === "owner"`. For `readonly` (recipient) and `anonymous` modes, the `checkedIds` Set is held in React state and never written to Firestore. Recipients always start with an empty checked set (`setCheckedIds(new Set())` in the readonly load branch).
+
+### Decision rationale (Likely)
+Likely: the team accepted "state lost on tab close" because a shared shopping session is short and the alternative (multi-writer sync) is disproportionately complex.
+
+### Consequences
+- Security rules for `shared_list_views` keep `allow write` gated on `request.auth.uid == ownerUid`; no anonymous write path exists.
+- Zero merge conflicts between concurrent recipients — each device has its own independent view.
+- Recipients always see a fresh, unchecked list on load, which matches "I'm about to start shopping" expectations.
+- ⚠️ Closing the tab or refreshing wipes recipient progress. If a recipient is mid-shop and their phone screen times out aggressively, they will lose check marks.
+- ⚠️ Recipients cannot collaborate (e.g. one person at the produce aisle, one at dairy) — each sees only their own check-offs. Revisit this ADR if explicit collaborative shopping is requested.
+
+### Related
+- UC-10 (Check off items) — owner path persists, recipient path does not
+- UC-13 (Share list) — defines the recipient role this ADR governs
+- ADR-01 (Share token as document ID) — public read rule depends on no public write path existing

--- a/docs/decisions/ADR-04-client-side-sort-replacing-orderby.md
+++ b/docs/decisions/ADR-04-client-side-sort-replacing-orderby.md
@@ -1,0 +1,25 @@
+---
+id: ADR-04
+status: Accepted
+date: 2026-05-17
+---
+
+## ADR-04 — Client-side sort replacing Firestore orderBy
+
+### Context
+`getUserLists` and `getMostRecentList` originally combined `where("ownerUid", "==", uid)` with `orderBy("updatedAt", "desc")`. Firestore requires a **composite index** on `(ownerUid ASC, updatedAt DESC)` for any query that filters one field and sorts on a different one. That index was never deployed: the initial `firebase deploy` step failed with a 401 auth error, and only the security rules were uploaded manually afterwards. Without the index Firestore throws at query time, the error was silently swallowed by a `Promise.all` with no `.catch()`, and the list switcher appeared empty (BUG-02). The proper fix is to deploy the composite index from `firestore.indexes.json` via `firebase deploy --only firestore`. That fix was blocked on the same auth issue and not pursued during the bug fix window.
+
+### Decision
+**This is a forced workaround, not a preferred design.** Both queries drop `orderBy` entirely, use only the single-field `where("ownerUid", "==", uid)` (which Firestore indexes automatically), and sort the result client-side by `updatedAt.toMillis()` descending in JS. The cost is paid per query rather than amortized into an index.
+
+### Consequences
+- Queries succeed immediately for any user without requiring an `firestore.indexes.json` deploy step.
+- The bug is unblocked without depending on resolving the Firebase CLI auth problem.
+- ⚠️ Sort cost is O(n) per call, computed on the client. For users with dozens of lists this is invisible; for users with thousands it would become noticeable. There is no upstream limit on list count today, so this scales linearly forever.
+- ⚠️ The entire matching document set is downloaded before sorting — Firestore cannot apply `limit()` meaningfully without an index because there is no server-side order to limit. `getMostRecentList` in particular reads every list the user owns just to pick the newest one.
+- ⚠️ **The proper solution is to deploy the composite index and restore `orderBy("updatedAt", "desc")` with `limit(1)` on `getMostRecentList`.** Revisit this ADR once the Firebase deploy auth is fixed and `firestore.indexes.json` is in place; the code change to revert is ~10 lines.
+
+### Related
+- BUG-02 (Saved lists not appearing in the list switcher) — the root cause this ADR documents
+- UC-2 (View shopping page, returning user) — depends on `getMostRecentList`
+- UC-12 (Multiple saved lists) — depends on `getUserLists`

--- a/docs/decisions/ADR-05-denormalized-ingredient-snapshot.md
+++ b/docs/decisions/ADR-05-denormalized-ingredient-snapshot.md
@@ -1,0 +1,26 @@
+---
+id: ADR-05
+status: Accepted
+date: 2026-05-17
+---
+
+## ADR-05 — Denormalized ingredient snapshot in shopping list recipes
+
+### Context
+A shopping list references recipes, and each recipe has an ingredient list that can change over time as the recipe is edited. Two storage shapes were possible: (a) store only `recipeId` references and re-fetch the full recipe on every page load to consolidate ingredients, or (b) snapshot the full ingredient list into the shopping list document at the moment the recipe is added. Option (a) means N extra Firestore reads per page load and produces surprising behaviour if the source recipe changes mid-shop (quantities silently mutate). Option (b) trades storage size and write effort for read simplicity and a stable "what I was shopping for at this moment" record.
+
+### Decision
+`IShoppingListRecipe` in `src/util/models.ts` carries a full `ingredients: IShoppingListIngredient[]` snapshot (id, name, aisles, quantity, unit) captured at add time by `recipeToShoppingListRecipe`. `buildConsolidationMap` and `buildAisles` operate exclusively on this snapshot — no recipe-catalog fetch is needed to render or consolidate.
+
+### Consequences
+- A single document read fetches everything needed to render and consolidate the list; the recipe catalog fetch is only used for autocomplete.
+- Shared views work without the recipient having any access to the `recipe/` collection — the snapshot travels with the share document.
+- Page renders are deterministic over the life of the list; an edit to the source recipe does not silently change what the user is shopping for.
+- ⚠️ Shopping list documents grow proportionally to (recipes × ingredients). A 20-recipe list with 10 ingredients each is ~200 embedded objects per document. Still well under Firestore's 1 MiB document limit, but worth watching.
+- ⚠️ No mechanism exists to "refresh recipe X to its latest version" inside an existing list. If a recipe was added with stale data, the user must remove and re-add it.
+
+### Related
+- UC-3 (Add recipes to the list) — captures the snapshot
+- UC-4 (Adjust portions) — scales from `basePortions` stored in the snapshot
+- UC-6, UC-7, UC-8 (Consolidation rules) — operate on the snapshot, not live recipe data
+- UC-13 (Share list) — snapshot is what gets shared

--- a/docs/decisions/ADR-06-pagemode-discriminant.md
+++ b/docs/decisions/ADR-06-pagemode-discriminant.md
@@ -1,0 +1,23 @@
+---
+id: ADR-06
+status: Accepted
+date: 2026-05-17
+---
+
+## ADR-06 — `pageMode` discriminant replacing two boolean constants
+
+### Context
+The shopping page has three mutually exclusive operating modes: an anonymous visitor, a logged-in owner, and a recipient viewing a shared link via `?token=`. An earlier version of the page used two boolean constants (`USER_IS_LOGGED_IN`, `IS_READONLY`) to gate behaviour, which permits the unrepresentable combination `logged-in && readonly` and forces every gated code path to evaluate both booleans together. Bugs of the form "I forgot to also check the other flag" are likely under that shape.
+
+### Decision
+`src/components/Shopping/types.ts` defines `type PageMode = 'owner' | 'readonly' | 'anonymous'`. `ShoppingPageContent` derives it once from auth + URL token (`shareToken ? "readonly" : user ? "owner" : "anonymous"`) and every gated handler (`toggleIngredient`, `handleSave`, `handleClear`, `handleShare`) compares against the single discriminant.
+
+### Consequences
+- The unrepresentable state is gone; TypeScript's `switch` exhaustiveness catches new modes if any are added.
+- Each handler has a single, readable guard (`if (pageMode !== "owner")`) instead of compound boolean expressions.
+- Derivation is centralized — auth and URL changes flow through one expression rather than multiple `useEffect`s.
+- ⚠️ Adding a fourth mode (e.g. "editor invited via link") requires touching every guard. The discriminant is correct for the current three roles but is not extensible to per-action permissions; if role complexity grows, a capability-bag pattern would replace this.
+
+### Related
+- UC-1 (Anonymous), UC-2 (Owner), UC-13 (Readonly recipient) — the three modes
+- UC-10 (Check off) — uses `pageMode === "owner"` to decide whether to persist

--- a/docs/decisions/ADR-07-useauth-hook-replaces-getuseruuid.md
+++ b/docs/decisions/ADR-07-useauth-hook-replaces-getuseruuid.md
@@ -1,0 +1,24 @@
+---
+id: ADR-07
+status: Accepted
+date: 2026-05-17
+---
+
+## ADR-07 — `useAuth` hook replaces synchronous `getUserUUID`
+
+### Context
+A previous helper `getUserUUID()` in `authentication.ts` returned `authApp.currentUser?.uid ?? null` synchronously. Firebase's `onAuthStateChanged` is asynchronous and `currentUser` is `null` until the SDK finishes restoring the session from IndexedDB, so any caller invoking `getUserUUID()` during the first render of a page reliably got `null` — even for users who were in fact logged in. The shopping page in particular needs the UID to load saved lists; using the broken helper meant logged users saw the anonymous experience on first render and only recovered if the page happened to re-render after auth resolved.
+
+### Decision
+A `useAuth()` hook in `src/hooks/useAuth.ts` subscribes to `onAuthStateChanged` in a `useEffect`, exposes `{ user, loading }`, and unsubscribes on unmount. The shopping page guards data loading with `if (authLoading) return;` inside its load effect, ensuring the first list-load attempt only fires after auth has resolved.
+
+### Consequences
+- The race condition is structurally impossible; data-loading effects can declare `authLoading` as a dependency and React schedules them correctly.
+- The `loading` flag enables intentional skeleton/blank states instead of flashes of the wrong UI.
+- The subscription is cleaned up on unmount, avoiding the memory leak the bare helper could not address.
+- ⚠️ Every consumer pays for its own subscription (one `onAuthStateChanged` listener per component using the hook). For the current handful of callers this is fine; a shared `AuthContext` provider would be the next step if usage grows.
+
+### Related
+- UC-2 (View shopping page, returning user) — depends on `useAuth` resolving before list load
+- UC-12 (Multiple saved lists) — same dependency
+- ADR-06 (`pageMode` discriminant) — `pageMode` derivation reads `user` from this hook

--- a/docs/templates/adr-template.md
+++ b/docs/templates/adr-template.md
@@ -1,0 +1,41 @@
+---
+id: ADR-NN
+status: Accepted
+date: YYYY-MM-DD
+---
+
+## ADR-NN — <Short title, max 10 words>
+
+### Context
+
+<!--
+What situation or constraint forced a decision to be made?
+Include technical facts, infrastructure limitations, or product requirements
+that are NOT obvious from reading the code alone.
+Answer: "why couldn't we just do the obvious thing?"
+-->
+
+### Decision
+
+<!--
+What was decided. One or two sentences, present tense.
+Be specific about data structures, APIs, or patterns chosen.
+-->
+
+### Consequences
+
+<!--
+Bullet list. Include both positive outcomes AND accepted limitations.
+Prefix with ⚠️ any consequence that would require revisiting this ADR
+if circumstances change.
+-->
+
+- …
+- ⚠️ …
+
+### Related
+
+<!--
+- UC or BUG entries this decision implements or constrains (e.g. UC-13, BUG-02)
+- Other ADRs this depends on or conflicts with
+-->

--- a/docs/templates/feature-kickoff.md
+++ b/docs/templates/feature-kickoff.md
@@ -1,0 +1,58 @@
+# Feature kick-off: <feature name>
+
+<!--
+HOW TO USE THIS TEMPLATE
+Copy the block below into a new Claude Code conversation (or paste it as your first message).
+Fill in what you know. Leave fields blank to have the agent ask you.
+Delete this comment block before sending.
+-->
+
+## What I want
+
+<Describe the feature. Scope, rough behaviour, which users it affects.
+No need to be exhaustive — the agent will draft UCs from this and show them to you.>
+
+## Why
+
+<!--
+Leave this blank if you want the agent to ask you for it before proceeding.
+Fill it in if you already know: one sentence on the problem this solves or what it unlocks.
+-->
+
+## Constraints and context I already know
+
+<!--
+Optional. Anything that would affect design:
+- Related features or shared data structures
+- Known technical constraints (Firestore limits, auth rules, routing)
+- Explicit out-of-scope items
+- Prior decisions or ADRs that apply
+-->
+
+-
+
+---
+
+<!--
+AGENT INSTRUCTIONS (leave this section in — the agent reads it)
+
+Before any design or implementation:
+1. If "Why" above is blank, ask for it now. One sentence is enough. Do not proceed until you have it.
+2. Read docs/usecases/ to check if a doc already exists for this feature.
+3. Draft a UC list from the description above and show it to me before writing any files.
+   Ask me to confirm scope, add missing UCs, or cut anything out of scope.
+4. Once I confirm, create docs/usecases/<feature-slug>.md from docs/templates/uc-template.md.
+   All UCs start as PLANNED.
+
+During implementation:
+- Update UC statuses as you build — do not batch them at the end.
+- Add BUG entries immediately when a bug is found and fixed.
+- Create ADR files in docs/decisions/ for non-obvious architectural decisions,
+  before moving on from that decision. Use docs/templates/adr-template.md.
+- Link UCs to ADRs with a "See: ADR-NN" line where relevant.
+
+When I say we're done or ask to open a PR:
+- Do a final doc pass: verify UC statuses against actual code, check for missing ADRs,
+  add a "Known gaps" section for anything deferred.
+- Report what the doc looks like before opening the PR.
+-->

--- a/docs/templates/uc-template.md
+++ b/docs/templates/uc-template.md
@@ -1,0 +1,80 @@
+# Use Cases: <Feature Name>
+
+Feature: <One sentence — what this feature does, for whom, and the core value it delivers.>
+
+**Why:** <One sentence — the motivation. What problem does this solve, or what does it unlock?>
+
+---
+
+## UC-1 — <Name>
+
+**Status:** `PLANNED` <!-- update to DONE / PARTIAL — <what's missing> when implemented -->
+
+**GIVEN** <precondition — system state and user context>
+**WHEN** <trigger — the action the user takes or the event that fires>
+**THEN** <observable outcome — what the user sees or what the system does>
+
+---
+
+## UC-2 — <Name>
+
+**Status:** `PLANNED`
+
+**GIVEN** …
+**WHEN** …
+**THEN** …
+
+---
+
+<!-- Add more UCs following the same pattern. -->
+<!-- UC numbering is sequential. Variants of a UC use lettered suffixes: UC-3b. -->
+
+---
+
+## Notes
+
+### <Business rule or reference table title>
+
+<!--
+Use this section for:
+- Reference tables (unit rules, permission matrices, persistence model)
+- Mixed-case or edge-case display formats
+- Constraints that cut across multiple UCs (write these as invariants, not prose)
+
+Example invariant block:
+**Invariants**
+- The same list object is always mutated on clear — a new document is never created.
+- Anonymous users have no write path to Firestore.
+-->
+
+---
+
+## Known gaps
+
+<!--
+Deliberately deferred scope. Add entries here rather than leaving UCs in PLANNED
+indefinitely when the decision to defer is intentional.
+
+Format:
+- <UC or capability> — deferred because <reason>. Revisit when <condition>.
+-->
+
+---
+
+## Bugs
+
+<!--
+Add BUG entries here as they are found and fixed. Do not wait until the end.
+
+### BUG-01 — <Short description> (<status: fixed in PR #N | open>)
+
+**Symptom:** What the user observed.
+
+**Root cause:** Why it happened. Be specific — file and function if relevant.
+
+**Fix:** What changed and why that resolves it.
+
+**Files changed:** `src/...`
+
+**See:** UC-N (which use case this bug affected)
+-->

--- a/docs/usecases/shopping-list.md
+++ b/docs/usecases/shopping-list.md
@@ -6,6 +6,9 @@ Feature: A dedicated `/shopping` page where users select recipes and receive a c
 
 ## UC-1 — View shopping page (anonymous)
 
+**Status:** `DONE` <!-- src/app/shopping/page.tsx:ShoppingPageContent (pageMode === "anonymous" + AnonBanner) -->
+**See:** ADR-06
+
 **GIVEN** a user is not logged in and navigates to `/shopping`  
 **WHEN** the page loads  
 **THEN** they see an empty list with a prompt to add recipes, and a banner saying "Log in to save your list across sessions"
@@ -13,6 +16,9 @@ Feature: A dedicated `/shopping` page where users select recipes and receive a c
 ---
 
 ## UC-2 — View shopping page (logged user, returning)
+
+**Status:** `DONE` <!-- src/lib/firebase/shoppingLists.ts:getMostRecentList; src/app/shopping/page.tsx useEffect "owner" branch -->
+**See:** ADR-04, ADR-06, ADR-07
 
 **GIVEN** a logged user navigates to `/shopping`  
 **WHEN** the page loads  
@@ -22,6 +28,9 @@ Feature: A dedicated `/shopping` page where users select recipes and receive a c
 
 ## UC-3 — Add recipes to the list
 
+**Status:** `DONE` <!-- src/app/shopping/page.tsx:addRecipe; src/util/shoppingListUtils.ts:recipeToShoppingListRecipe -->
+**See:** ADR-05
+
 **GIVEN** a user is on `/shopping`  
 **WHEN** they search and select one or more recipes from the selector  
 **THEN** the recipes appear as chips at the top of the page and the ingredient list updates immediately
@@ -29,6 +38,8 @@ Feature: A dedicated `/shopping` page where users select recipes and receive a c
 ---
 
 ## UC-4 — Adjust portions per recipe
+
+**Status:** `DONE` <!-- src/app/shopping/page.tsx:changePortions; src/util/shoppingListUtils.ts:scaleIngredient -->
 
 **GIVEN** a user has added a recipe to the list  
 **WHEN** they change the portion multiplier (e.g. ×2) on that recipe's chip  
@@ -38,6 +49,8 @@ Feature: A dedicated `/shopping` page where users select recipes and receive a c
 
 ## UC-5 — Remove a recipe from the list
 
+**Status:** `DONE` <!-- src/app/shopping/page.tsx:removeRecipe -->
+
 **GIVEN** a user has recipes in their list  
 **WHEN** they dismiss a recipe chip  
 **THEN** the consolidated ingredient list recalculates removing that recipe's contribution
@@ -45,6 +58,8 @@ Feature: A dedicated `/shopping` page where users select recipes and receive a c
 ---
 
 ## UC-6 — Metric unit consolidation
+
+**Status:** `DONE` <!-- src/util/shoppingListUtils.ts:resolveQty + toGrams/toMl/formatMass/formatVolume -->
 
 **GIVEN** the same ingredient appears across recipes with compatible metric units (`grs`/`kg` or `ml`/`lt`)  
 **WHEN** the list is rendered  
@@ -54,6 +69,8 @@ Feature: A dedicated `/shopping` page where users select recipes and receive a c
 
 ## UC-7 — Mixed unit merging (same ingredient, incompatible units)
 
+**Status:** `DONE` <!-- src/util/shoppingListUtils.ts:resolveQty mixed-group branch (joins parts with " + ") -->
+
 **GIVEN** the same ingredient appears in two recipes with incompatible units (e.g. `300grs` and `2 unidades`)  
 **WHEN** the list is rendered  
 **THEN** both quantities are shown on a single line: "Tomatoes — 300g + 2 units" (no forced conversion)
@@ -61,6 +78,8 @@ Feature: A dedicated `/shopping` page where users select recipes and receive a c
 ---
 
 ## UC-8 — Non-metric units left as-is
+
+**Status:** `DONE` <!-- src/util/shoppingListUtils.ts:resolveQty culinary/count groups -->
 
 **GIVEN** an ingredient uses `cdta`, `cda`, `tz`, or `unidad`  
 **WHEN** the same ingredient appears multiple times with the same non-metric unit  
@@ -70,6 +89,8 @@ Feature: A dedicated `/shopping` page where users select recipes and receive a c
 
 ## UC-9 — Sort by aisle (default)
 
+**Status:** `DONE` <!-- src/util/shoppingListUtils.ts:buildAisles (sortMode 'aisle' grouped by marketAisles); src/components/Shopping/organisms/AisleGroup.tsx -->
+
 **GIVEN** a user has a populated shopping list  
 **WHEN** the list renders (or they select "By aisle" sort)  
 **THEN** ingredients are grouped under collapsible aisle headers, ordered to match a logical supermarket walk
@@ -77,6 +98,9 @@ Feature: A dedicated `/shopping` page where users select recipes and receive a c
 ---
 
 ## UC-10 — Check off items while shopping
+
+**Status:** `DONE` <!-- src/app/shopping/page.tsx:toggleIngredient; src/lib/firebase/shoppingLists.ts:updateChecked -->
+**See:** ADR-03, ADR-06
 
 **GIVEN** a user is viewing their shopping list  
 **WHEN** they tap a checkbox next to an ingredient  
@@ -86,6 +110,8 @@ Feature: A dedicated `/shopping` page where users select recipes and receive a c
 
 ## UC-11 — Clear list and start over (logged user)
 
+**Status:** `PARTIAL — handleClear logic exists in page.tsx but is not wired to any UI; ActionBar has no Clear button and no confirmation dialog component exists` <!-- src/app/shopping/page.tsx:handleClear (defined but unreferenced); src/components/Shopping/organisms/ActionBar.tsx (no onClear prop); no ClearListDialog under src/components/Shopping/dialogs/ -->
+
 **GIVEN** a logged user has an existing list  
 **WHEN** they tap "Clear list" and confirm  
 **THEN** the current list is wiped (recipes and check-off state reset) and they start fresh — no new list is created, the same list object is reused
@@ -93,6 +119,9 @@ Feature: A dedicated `/shopping` page where users select recipes and receive a c
 ---
 
 ## UC-12 — Multiple saved lists (logged user)
+
+**Status:** `DONE` <!-- src/app/shopping/page.tsx:handleNewList + handleSelectList; src/components/Shopping/dialogs/ListSwitcherModal.tsx; src/lib/firebase/shoppingLists.ts:createList + getUserLists -->
+**See:** ADR-04, ADR-07
 
 **GIVEN** a logged user wants to plan for different occasions  
 **WHEN** they tap "New list"  
@@ -102,6 +131,9 @@ Feature: A dedicated `/shopping` page where users select recipes and receive a c
 
 ## UC-13 — Share list (read-only + checkable)
 
+**Status:** `DONE` <!-- src/lib/firebase/shoppingLists.ts:shareList (writeBatch updates shopping_lists + creates shared_list_views/{token}); src/app/shopping/page.tsx:handleShare; src/components/Shopping/dialogs/ShareDialog.tsx -->
+**See:** ADR-01, ADR-03
+
 **GIVEN** a logged user has a list they want to share  
 **WHEN** they tap "Share" and copy the generated link  
 **THEN** a link is generated in the form `https://bastiann-corp.github.io/FoodPlanerReact/shopping?token=<shareToken>` and anyone with that link can open it, see the full ingredient list, and check items off — but cannot add/remove recipes or edit quantities
@@ -110,6 +142,9 @@ Feature: A dedicated `/shopping` page where users select recipes and receive a c
 
 ## UC-13b — Shared list stays in sync
 
+**Status:** `PARTIAL — saveList calls syncSharedView via a sequential await rather than a single writeBatch, so the canonical list and shared snapshot are not written atomically` <!-- src/lib/firebase/shoppingLists.ts:saveList (setDoc/addDoc, then await syncSharedView with updateDoc — two separate round-trips, not batched) -->
+**See:** ADR-02
+
 **GIVEN** a logged user has shared a list and later modifies it (adds/removes recipes, changes portions)  
 **WHEN** they save the list  
 **THEN** the shared view is updated atomically in the same write — any recipient who refreshes their link sees the current state immediately, with no action required from the owner
@@ -117,6 +152,8 @@ Feature: A dedicated `/shopping` page where users select recipes and receive a c
 ---
 
 ## UC-14 — Export to clipboard (Google Keep format)
+
+**Status:** `DONE` <!-- src/app/shopping/page.tsx:handleCopy; src/util/shoppingListUtils.ts:buildKeepText -->
 
 **GIVEN** a user has a shopping list  
 **WHEN** they tap "Copy for Keep"  
@@ -223,6 +260,8 @@ Recipients can check items off while shopping, but that state is held **in-memor
 
 ### BUG-01 — Recipe chips overflow horizontally on mobile (fixed in PR #8)
 
+**Status:** `FIXED in PR #8 (e7e8832)` <!-- src/components/Shopping/organisms/RecipeSelector.tsx (flexWrap: 'wrap') -->
+
 **Symptom:** On small screens or narrow windows, selected recipe chips in the `RecipeSelector` formed a single horizontal row with hidden overflow scroll. This made chips unreachable and hid the remove button on the last chip.
 
 **Root cause:** The chip container had `flexWrap: { xs: 'nowrap', md: 'wrap' }` combined with `overflowX: 'auto'`, deliberately enabling horizontal scroll on mobile. This was a design decision that turned out to degrade usability.
@@ -234,6 +273,9 @@ Recipients can check items off while shopping, but that state is held **in-memor
 ---
 
 ### BUG-02 — Saved lists not appearing in the list switcher (fixed in PR #8)
+
+**Status:** `FIXED in PR #8 (fdbc20a)` <!-- src/lib/firebase/shoppingLists.ts:getUserLists + getMostRecentList (orderBy removed, client-side sort by updatedAt); src/app/shopping/page.tsx Promise.all .catch added -->
+**See:** ADR-04
 
 **Symptom:** Logged-in users opened the "Mi lista" dropdown and saw no lists, even when lists existed in Firestore.
 


### PR DESCRIPTION
## Summary

- **Status badge on every UC and BUG entry** in `docs/usecases/shopping-list.md`, sourced from actual code paths (cited in HTML comments)
- **7 new ADRs** under `docs/decisions/` documenting implicit architectural choices that aren't obvious from the code alone
- **Cross-links** added from UCs/BUGs to the ADRs that govern them

## ADRs added

| ADR | Topic |
|---|---|
| ADR-01 | Share token as Firestore document ID |
| ADR-02 | Batch write for owner save + share sync |
| ADR-03 | Recipient check-off held in memory only |
| ADR-04 | Client-side sort replacing Firestore orderBy (forced fix, not preferred) |
| ADR-05 | Denormalized ingredient snapshot in shopping list |
| ADR-06 | `pageMode` discriminant replacing two booleans |
| ADR-07 | `useAuth` hook replaces broken `getUserUUID` |

## Status callouts

- **UC-11 (Clear list)** — `PARTIAL`: `handleClear` is defined in `page.tsx` but never wired to UI. No Clear button in `ActionBar`, no confirmation dialog component.
- **UC-13b (Shared list sync)** — `PARTIAL`: `saveList` calls `syncSharedView` sequentially rather than in one `writeBatch`, so the "atomic" promise is approximate. Tracked in ADR-02 consequences.

All other UCs are `DONE`. Both BUGs from PR #8 are `FIXED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)