### PR TITLE
feat: latest recipes strip on /recipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@
 *.pem
 */firebase-config.ts
 .claude/settings.local.json
+.claude/launch.json
+nul
 
 # debug
 npm-debug.log*

--- a/docs/usecases/latest-recipes-strip.md
+++ b/docs/usecases/latest-recipes-strip.md
@@ -1,0 +1,123 @@
+# Use Cases: Latest Recipes Strip
+
+Feature: A horizontal, scrollable strip at the top of `/recipes` showing the 7 most recently added recipes as compact cards. Surfaces newcomer activity, highlights fresh content, and encourages users to contribute their own recipes.
+
+**Why:** Signal that the app is active and receiving new content; create social proof that nudges users into adding recipes themselves.
+
+---
+
+## UC-1 — View latest recipes strip
+
+**Status:** `DONE` <!-- src/app/recipes/page.tsx mounts `<LatestRecipesStrip />`; src/components/Recipe/LatestRecipesStrip.tsx -->
+
+**GIVEN** a user navigates to `/recipes`
+**WHEN** the page loads
+**THEN** a horizontal strip labeled "ÚLTIMAS RECETAS" appears above the filter sidebar and recipe list, showing up to 7 recipes ordered by `createdAt` descending
+
+---
+
+## UC-2 — Identify the most recent recipe
+
+**Status:** `DONE` <!-- src/components/Recipe/RecipeCard.tsx (`isLatest` prop renders "Última" badge); LatestRecipesStrip passes `idx === 0` -->
+
+**GIVEN** the latest recipes strip is rendered with at least one card
+**WHEN** the user looks at the first card in the strip
+**THEN** the first card displays an "Última" badge in the top-right corner, distinguishing it from the others
+
+---
+
+## UC-3 — Scroll the strip horizontally
+
+**Status:** `DONE` <!-- src/components/Recipe/LatestRecipesStrip.tsx (`overflowX: auto` + hidden scrollbar) -->
+
+**GIVEN** the strip contains more cards than fit in the viewport (typical on mobile)
+**WHEN** the user swipes / scrolls horizontally on the strip
+**THEN** the cards scroll to reveal the next ones, with the scrollbar hidden for a clean appearance
+
+---
+
+## UC-4 — Open a recipe from the strip
+
+**Status:** `DONE` <!-- src/components/Recipe/RecipeCard.tsx (`component="a"` with `href={envVars.baseURL + /recipes/${id}}`) -->
+
+**GIVEN** the user sees a recipe card in the strip
+**WHEN** they click / tap the card
+**THEN** they navigate to that recipe's detail page (`/recipes/[id]`), same target as the existing list rows
+
+---
+
+## UC-5 — Recipe receives a creation timestamp
+
+**Status:** `DONE` <!-- src/lib/firebase/recipes.ts:createRecipe injects `createdAt: serverTimestamp()` -->
+
+**GIVEN** a logged-in user submits a new recipe via `/recipes/create`
+**WHEN** the recipe is written to Firestore
+**THEN** the document is created with `createdAt` and `modifiedAt` set to the Firestore server timestamp, and it becomes eligible to appear in the strip
+
+---
+
+## UC-6 — Recipe receives a modification timestamp
+
+**Status:** `DONE` <!-- src/lib/firebase/recipes.ts:updateRecipe & updateRecipeIngredients set `modifiedAt: serverTimestamp()` -->
+
+**GIVEN** a logged-in user edits an existing recipe (full update or ingredients-only update)
+**WHEN** the change is written to Firestore
+**THEN** the document's `modifiedAt` field is set to the current server timestamp; `createdAt` is never touched
+
+---
+
+## UC-7 — Strip handles recipes without `createdAt`
+
+**Status:** `DONE` <!-- src/lib/firebase/recipes.ts:getLatestRecipes uses orderBy("createdAt","desc"); src/components/Recipe/LatestRecipesStrip.tsx returns null when empty -->
+
+**GIVEN** Firestore contains legacy recipes written before the timestamp fields existed
+**WHEN** the strip queries the latest 7 recipes
+**THEN** legacy recipes (lacking `createdAt`) are excluded from the query result — effectively treated as the oldest — and the strip displays only timestamped recipes. The accordion list below the strip continues to show every recipe regardless of timestamp.
+
+---
+
+## Notes
+
+### Card anatomy
+
+Each card in the strip is 148 px wide and includes:
+
+- 3 px colored accent bar at the top, tinted per food family
+- 52 × 52 emoji avatar with a family-tinted background
+- Recipe name (2-line clamp)
+- Family label
+- Portions pill (`👤 N por.`)
+- Optional creation date (controlled by a prop, **default off** until legacy recipes are backfilled)
+- "Última" badge — only on the newest card (index 0)
+
+### Family accent colors
+
+Pulled from the existing MUI palette in [`src/styles/theme.ts`](../../src/styles/theme.ts):
+
+| Family | Color |
+|---|---|
+| starters, fish | `info.main` (#008395) |
+| veggies, beans, others | `primary.main` (#7cb342) |
+| carbs, bakery | `warning.main` (#b9a440) |
+| birds | `secondary.main` (#ff8f00) |
+| meat, desserts | `error.main` (#a64529) |
+
+### Invariants
+
+- `createdAt` is set once on creation and never modified.
+- `modifiedAt` is touched on every recipe update.
+- The strip query uses `orderBy("createdAt", "desc").limit(7)` — Firestore silently excludes documents missing the field.
+- The existing "Nueva receta" button at the top of the page stays where it is; the strip header has no action button.
+
+---
+
+## Known gaps
+
+- **Legacy recipe backfill** — deferred. Existing recipes without `createdAt` are invisible to the strip until edited. Revisit if the strip looks sparse in production or when the "Recently modified" feature is built (which will read `modifiedAt`).
+- **`modifiedAt` consumer** — the field is written but not yet read by any UI. It exists to unblock a future "Recently modified" feature.
+
+---
+
+## Bugs
+
+<!-- None yet -->

--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -13,6 +13,7 @@ import {IRecipe} from "@/util/models";
 import {foodFamilies, seasons} from "@/util/constants";
 import {getRecipes} from "@/lib/firebase/recipes";
 import {AccordionRecipe} from "@/components/Recipe/AccordeonRecipe";
+import {LatestRecipesStrip} from "@/components/Recipe/LatestRecipesStrip";
 import {envVars} from "@/util/config";
 
 
@@ -116,6 +117,7 @@ export default function Recipes() {
         >Nueva receta</Button>
       </Grid2>
     </Grid2>
+    <LatestRecipesStrip />
     <Grid2 container spacing={2} direction={"row"} columns={{ xs: 6, sm: 6, md: 12, lg:12, xl:12 }} paddingBottom={10}>
       <Grid2 size={{xs: 6, sm: 6, md: 2, lg:2, xl:2}}>
         <TextField

--- a/src/components/Recipe/LatestRecipesStrip.tsx
+++ b/src/components/Recipe/LatestRecipesStrip.tsx
@@ -1,0 +1,90 @@
+"use client"
+import React, {useEffect, useState} from "react";
+import {Box, Skeleton, Typography} from "@mui/material";
+import {IRecipe} from "@/util/models";
+import {getLatestRecipes} from "@/lib/firebase/recipes";
+import {RecipeCard} from "@/components/Recipe/RecipeCard";
+
+interface LatestRecipesStripProps {
+  /** Show creation date on each card. Default off until existing recipes have timestamps. */
+  showDate?: boolean;
+  /** How many recipes to fetch. Defaults to 7 to match the design. */
+  count?: number;
+}
+
+export function LatestRecipesStrip({showDate = false, count = 7}: LatestRecipesStripProps) {
+  const [recipes, setRecipes] = useState<IRecipe[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      const data = await getLatestRecipes(count);
+      if (!cancelled) {
+        setRecipes(data);
+        setIsLoading(false);
+      }
+    }
+    load();
+    return () => { cancelled = true; };
+  }, [count]);
+
+  // Hide the strip when there are no timestamped recipes yet — avoids a confusing empty block.
+  if (!isLoading && recipes.length === 0) return null;
+
+  return (
+    <Box sx={{padding: '16px 16px 0'}}>
+      {/* Section header */}
+      <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '14px'}}>
+        <Box>
+          <Typography
+            sx={{
+              fontSize: 11,
+              fontWeight: 700,
+              color: 'rgba(255,255,255,.60)',
+              textTransform: 'uppercase',
+              letterSpacing: '1.1px',
+              lineHeight: 1.4,
+            }}
+          >
+            Últimas recetas
+          </Typography>
+          <Typography sx={{fontSize: 11, color: 'rgba(255,255,255,.38)', marginTop: '1px'}}>
+            Creadas recientemente
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* Horizontal strip */}
+      <Box
+        sx={{
+          display: 'flex',
+          gap: '10px',
+          overflowX: 'auto',
+          padding: '4px 2px 20px',
+          scrollbarWidth: 'none',
+          '&::-webkit-scrollbar': {display: 'none'},
+        }}
+      >
+        {isLoading
+          ? Array.from({length: count}).map((_, i) => (
+              <Skeleton
+                key={`skeleton-${i}`}
+                variant="rounded"
+                width={148}
+                height={196}
+                sx={{flexShrink: 0, borderRadius: '14px'}}
+              />
+            ))
+          : recipes.map((recipe, idx) => (
+              <RecipeCard
+                key={recipe.id ?? `latest-${idx}`}
+                recipe={recipe}
+                isLatest={idx === 0}
+                showDate={showDate}
+              />
+            ))}
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/Recipe/RecipeCard.tsx
+++ b/src/components/Recipe/RecipeCard.tsx
@@ -1,0 +1,163 @@
+import React from "react";
+import {Box, Typography} from "@mui/material";
+import {PeopleAltRounded} from "@mui/icons-material";
+import {IRecipe} from "@/util/models";
+import {FAMILY_ACCENTS, foodFamilies} from "@/util/constants";
+import {envVars} from "@/util/config";
+
+interface RecipeCardProps {
+  recipe: IRecipe;
+  isLatest?: boolean;
+  showDate?: boolean;
+}
+
+function getFamilyData(familyId: string) {
+  return foodFamilies.find(f => f.id === familyId) ?? {name: familyId, id: familyId, icon: '🍽️'};
+}
+
+function formatShortDate(d: Date) {
+  return d.toLocaleDateString('es-ES', {day: 'numeric', month: 'short'});
+}
+
+export function RecipeCard({recipe, isLatest = false, showDate = false}: RecipeCardProps) {
+  const family = getFamilyData(recipe.family);
+  const accent = FAMILY_ACCENTS[recipe.family] ?? '#7cb342';
+  const createdAt = recipe.createdAt?.toDate?.();
+
+  return (
+    <Box
+      component="a"
+      href={envVars.baseURL + `/recipes/${recipe.id}`}
+      sx={{
+        flexShrink: 0,
+        width: 148,
+        backgroundColor: '#272727',
+        border: '1px solid rgba(255,255,255,.12)',
+        borderRadius: '14px',
+        overflow: 'hidden',
+        cursor: 'pointer',
+        display: 'flex',
+        flexDirection: 'column',
+        position: 'relative',
+        textDecoration: 'none',
+        color: 'inherit',
+        transition: 'transform .18s, border-color .18s, box-shadow .18s',
+        '&:hover': {
+          transform: 'translateY(-3px)',
+          borderColor: 'rgba(124,179,66,.28)',
+          boxShadow: '0 8px 24px rgba(0,0,0,.45)',
+        },
+        '&:active': {transform: 'scale(.97)'},
+      }}
+    >
+      {/* Accent bar */}
+      <Box sx={{height: 3, width: '100%', backgroundColor: accent}} />
+
+      {/* Body */}
+      <Box
+        sx={{
+          padding: '12px 10px 14px',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '7px',
+          flex: 1,
+        }}
+      >
+        {/* "Última" badge on the newest card */}
+        {isLatest && (
+          <Box
+            sx={{
+              position: 'absolute',
+              top: 10,
+              right: 8,
+              backgroundColor: accent,
+              borderRadius: '8px',
+              padding: '1px 7px',
+              fontSize: 9,
+              fontWeight: 700,
+              color: '#fff',
+              letterSpacing: '.5px',
+              textTransform: 'uppercase',
+              lineHeight: 1.4,
+            }}
+          >
+            Última
+          </Box>
+        )}
+
+        {/* Emoji avatar */}
+        <Box
+          sx={{
+            width: 52,
+            height: 52,
+            borderRadius: '14px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: 26,
+            backgroundColor: `${accent}20`,
+            border: `1px solid ${accent}38`,
+          }}
+        >
+          {family.icon}
+        </Box>
+
+        {/* Name */}
+        <Typography
+          sx={{
+            fontSize: 13,
+            fontWeight: 500,
+            color: 'rgba(255,255,255,.87)',
+            textAlign: 'center',
+            lineHeight: 1.3,
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+            width: '100%',
+          }}
+        >
+          {recipe.name}
+        </Typography>
+
+        {/* Family label */}
+        <Typography
+          sx={{
+            fontSize: 11,
+            color: 'rgba(255,255,255,.60)',
+            textAlign: 'center',
+          }}
+        >
+          {family.name}
+        </Typography>
+
+        {/* Portions + date */}
+        <Box sx={{display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '4px', marginTop: 'auto'}}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '4px',
+              borderRadius: '10px',
+              padding: '2px 8px',
+              backgroundColor: `${accent}18`,
+              border: `1px solid ${accent}30`,
+            }}
+          >
+            <PeopleAltRounded sx={{fontSize: 11, color: accent}} />
+            <Typography sx={{fontSize: 11, fontWeight: 500, color: accent}}>
+              {recipe.portions} por.
+            </Typography>
+          </Box>
+
+          {showDate && createdAt && (
+            <Typography sx={{fontSize: 10, color: 'rgba(255,255,255,.38)', letterSpacing: '.3px'}}>
+              {formatShortDate(createdAt)}
+            </Typography>
+          )}
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/lib/firebase/recipes.ts
+++ b/src/lib/firebase/recipes.ts
@@ -6,9 +6,12 @@ import {
   doc,
   FirestoreError,
   getDoc,
+  limit,
   orderBy,
   query,
-  Query, updateDoc,
+  Query,
+  serverTimestamp,
+  updateDoc,
   where
 } from "@firebase/firestore";
 import {createDocOutput, getConvertedDocs} from "@/lib/firebase/firestore";
@@ -85,6 +88,20 @@ export async function getRecipes({id, name, season, family} : IFilterRecipes) : 
   }
 }
 
+/** Fetch the N most recently created recipes (ordered by `createdAt` desc).
+ *  Recipes missing `createdAt` are excluded by Firestore — treated as the oldest. */
+export async function getLatestRecipes(n: number = 7) : Promise<IRecipe[]> {
+  try {
+    const recipes = await getConvertedDocs({
+      coll: {collection: collName, converter},
+      queryFilters: (q: Query): Query => query(q, orderBy("createdAt", "desc"), limit(n))
+    })
+    return recipes.map((doc) => doc as IRecipe)
+  } catch (error) {
+    return []
+  }
+}
+
 
 export interface ICreateRecipeInput {
   name: string;
@@ -111,7 +128,11 @@ export function validateRecipeCreation(args: ICreateRecipeInput) : boolean {
 
 export async function createRecipe(args: ICreateRecipeInput): Promise<createDocOutput> {
   try {
-    const data : IRecipe = args
+    const data = {
+      ...args,
+      createdAt: serverTimestamp(),
+      modifiedAt: serverTimestamp(),
+    }
     const docRef = await addDoc(
       collection(firestoreDB, collName),
       data
@@ -140,7 +161,7 @@ export async function deleteRecipe(documentId:string): Promise<string> {
 export async function updateRecipe(recipe:IRecipe): Promise<IRecipe | undefined> {
   try {
     const docRef = doc(firestoreDB, collName, recipe.id!);
-    const result = await updateDoc(docRef, recipe)
+    const result = await updateDoc(docRef, {...recipe, modifiedAt: serverTimestamp()})
     return getRecipeById(recipe.id!)
   } catch (error) {
     const err = error as FirestoreError;
@@ -153,7 +174,7 @@ export async function updateRecipeIngredients(docId: string, ingredients:IRecipe
   try {
     console.debug(`Updating recipe ${docId}:`, ingredients)
     const docRef = doc(firestoreDB, collName, docId);
-    await updateDoc(docRef, {ingredients_list: ingredients}).then((res)=>{
+    await updateDoc(docRef, {ingredients_list: ingredients, modifiedAt: serverTimestamp()}).then((res)=>{
       console.debug('Receta actualizada', res)
     }).catch((e)=>{
       console.error(`Error: ${e.name}: ${e.message}`);

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -264,3 +264,18 @@ export const recipeSections: ICategory[] = [
   {id:'once', name:'Once'},
   {id:'cena', name:'Cena'},
 ]
+
+// Per-family accent colors used by the latest recipes strip cards.
+// Values mirror the MUI palette in src/styles/theme.ts so they stay in sync.
+export const FAMILY_ACCENTS: Record<TFoodFamily, string> = {
+  starters: '#008395', // info.main
+  veggies:  '#7cb342', // primary.main
+  carbs:    '#b9a440', // warning.main
+  fish:     '#008395', // info.main
+  birds:    '#ff8f00', // secondary.main
+  meat:     '#a64529', // error.main
+  beans:    '#7cb342', // primary.main
+  desserts: '#a64529', // error.main
+  bakery:   '#b9a440', // warning.main
+  others:   '#7cb342', // primary.main
+}

--- a/src/util/models.ts
+++ b/src/util/models.ts
@@ -56,6 +56,8 @@ export interface IRecipe extends DocumentData{
   notes?: string;
   creator?: string;
   editors?: string[];
+  createdAt?: Timestamp;
+  modifiedAt?: Timestamp;
 }
 
 export interface IMenuRecipe {


### PR DESCRIPTION
## Intro

Adds a horizontal scrollable strip of the **7 most recently created recipes** to the top of `/recipes`. The goal is to signal that the app is active and receiving new content, and to nudge users into adding their own.

The strip pulls live from Firestore (`orderBy("createdAt","desc").limit(7)`), so it stays fresh as new recipes are added. To enable this ordering, `IRecipe` now carries optional `createdAt` and `modifiedAt` server timestamps, written automatically on create and on every update.

> **Note on existing recipes:** legacy recipes (created before this PR) have no `createdAt` and are silently excluded from the strip query — Firestore drops docs missing the orderBy field. The strip hides itself entirely while empty, so users see no broken state. As new recipes are added the strip fills up. No backfill is performed in this PR; that's deliberate and tracked under *Known gaps*.

---

## Feature

A dedicated horizontal strip at the top of `/recipes` showing the 7 most recently added recipes as compact cards. Each card surfaces fresh content, highlights the very latest with an "Última" badge, and links directly to the recipe detail page.

### Card anatomy

Each card is **148 px wide** and includes:

- 3 px colored accent bar at the top, tinted per food family
- 52 × 52 emoji avatar with a family-tinted background
- Recipe name (2-line clamp)
- Family label
- Portions pill (`👤 N por.`)
- Optional creation date (controlled by a prop, **default off** until legacy recipes are backfilled)
- "Última" badge — only on the newest card (index 0)

### Family accent colors

Pulled from the existing MUI palette in `src/styles/theme.ts`:

| Family | Color |
|---|---|
| starters, fish | `info.main` (#008395) |
| veggies, beans, others | `primary.main` (#7cb342) |
| carbs, bakery | `warning.main` (#b9a440) |
| birds | `secondary.main` (#ff8f00) |
| meat, desserts | `error.main` (#a64529) |

### Invariants

- `createdAt` is set once on creation and never modified.
- `modifiedAt` is touched on every recipe update.
- The strip query uses `orderBy("createdAt", "desc").limit(7)` — Firestore silently excludes documents missing the field.
- The existing "Nueva receta" button at the top of the page stays where it is; the strip header has no action button.

---

## Preview

**Desktop**

<img width="1280" alt="Latest recipes strip — desktop view" src="https://github.com/user-attachments/assets/334b1deb-cda0-474d-a8c3-e1f16119df77" />

**Mobile** — initial view with the "Última" badge on the first card, and a scrolled state showing more cards

<table>
  <tr>
    <td width="50%" valign="top" align="center">
      <img alt="Mobile — strip initial state with Última badge" src="https://github.com/user-attachments/assets/be52c15c-a5c0-41f1-a123-140e87c46f36" />
    </td>
    <td width="50%" valign="top" align="center">
      <img alt="Mobile — strip scrolled to show more cards" src="https://github.com/user-attachments/assets/6885fea4-5dca-4e30-98c6-9f12409767f9" />
    </td>
  </tr>
</table>

---

## Use Cases

### UC-1 — View latest recipes strip

**GIVEN** a user navigates to `/recipes`
**WHEN** the page loads
**THEN** a horizontal strip labeled "ÚLTIMAS RECETAS" appears above the filter sidebar and recipe list, showing up to 7 recipes ordered by `createdAt` descending

### UC-2 — Identify the most recent recipe

**GIVEN** the latest recipes strip is rendered with at least one card
**WHEN** the user looks at the first card in the strip
**THEN** the first card displays an "Última" badge in the top-right corner, distinguishing it from the others

### UC-3 — Scroll the strip horizontally

**GIVEN** the strip contains more cards than fit in the viewport (typical on mobile)
**WHEN** the user swipes / scrolls horizontally on the strip
**THEN** the cards scroll to reveal the next ones, with the scrollbar hidden for a clean appearance

### UC-4 — Open a recipe from the strip

**GIVEN** the user sees a recipe card in the strip
**WHEN** they click / tap the card
**THEN** they navigate to that recipe's detail page (`/recipes/[id]`), same target as the existing list rows

### UC-5 — Recipe receives a creation timestamp

**GIVEN** a logged-in user submits a new recipe via `/recipes/create`
**WHEN** the recipe is written to Firestore
**THEN** the document is created with `createdAt` and `modifiedAt` set to the Firestore server timestamp, and it becomes eligible to appear in the strip

### UC-6 — Recipe receives a modification timestamp

**GIVEN** a logged-in user edits an existing recipe (full update or ingredients-only update)
**WHEN** the change is written to Firestore
**THEN** the document's `modifiedAt` field is set to the current server timestamp; `createdAt` is never touched

### UC-7 — Strip handles recipes without `createdAt`

**GIVEN** Firestore contains legacy recipes written before the timestamp fields existed
**WHEN** the strip queries the latest 7 recipes
**THEN** legacy recipes (lacking `createdAt`) are excluded from the query result — effectively treated as the oldest — and the strip displays only timestamped recipes. The accordion list below the strip continues to show every recipe regardless of timestamp.

### Known gaps

- **Legacy recipe backfill** — deferred. Existing recipes without `createdAt` are invisible to the strip until edited. Revisit if the strip looks sparse in production or when the "Recently modified" feature is built.
- **`modifiedAt` consumer** — the field is written but not yet read by any UI. It exists to unblock a future "Recently modified" feature.

---

## Test plan

- [x] Visit `/recipes` on mobile (≤ 430 px) — confirm strip is hidden until a new recipe exists, then renders with horizontal scroll
- [x] Visit `/recipes` on desktop — confirm strip flows full-width above the filter/list grid
- [ ] Create a new recipe via `/recipes/create` — confirm it appears as the first card with the "Última" badge
- [ ] Edit an existing recipe (full update + ingredients-only update) — confirm `modifiedAt` is updated in Firestore (`createdAt` untouched)
- [x] Click a card — confirm navigation to `/recipes/[id]`
- [x] Existing accordion list below the strip still shows every recipe (including legacy ones with no timestamp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
